### PR TITLE
feat(frontier): implement URL Frontier with priority queue and deduplication

### DIFF
--- a/pkg/frontier/canonical.go
+++ b/pkg/frontier/canonical.go
@@ -1,0 +1,67 @@
+package frontier
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Canonicalize normalizes a URL following RFC 3986 conventions:
+//   - Lowercases the scheme and host
+//   - Removes default ports (80 for http, 443 for https)
+//   - Removes fragment
+//   - Sorts query parameters
+//   - Removes trailing slash on path (except root "/")
+//   - Decodes unnecessary percent-encoding
+func Canonicalize(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	// Lowercase scheme and host.
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+
+	// Remove default ports.
+	host := u.Hostname()
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		u.Host = host
+	}
+
+	// Remove fragment.
+	u.Fragment = ""
+
+	// Sort query parameters.
+	if u.RawQuery != "" {
+		params := u.Query()
+		keys := make([]string, 0, len(params))
+		for k := range params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		var buf strings.Builder
+		for i, k := range keys {
+			values := params[k]
+			sort.Strings(values)
+			for j, v := range values {
+				if i > 0 || j > 0 {
+					buf.WriteByte('&')
+				}
+				buf.WriteString(url.QueryEscape(k))
+				buf.WriteByte('=')
+				buf.WriteString(url.QueryEscape(v))
+			}
+		}
+		u.RawQuery = buf.String()
+	}
+
+	// Remove trailing slash (except root path).
+	if len(u.Path) > 1 {
+		u.Path = strings.TrimRight(u.Path, "/")
+	}
+
+	return u.String()
+}

--- a/pkg/frontier/dedup.go
+++ b/pkg/frontier/dedup.go
@@ -1,0 +1,50 @@
+package frontier
+
+import "sync"
+
+// Deduplicator tracks seen URLs to avoid processing duplicates.
+type Deduplicator struct {
+	mu   sync.RWMutex
+	seen map[string]struct{}
+}
+
+// NewDeduplicator creates a new hash-set based deduplicator.
+func NewDeduplicator() *Deduplicator {
+	return &Deduplicator{
+		seen: make(map[string]struct{}),
+	}
+}
+
+// IsSeen returns true if the URL has already been seen.
+func (d *Deduplicator) IsSeen(url string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.seen[url]
+	return ok
+}
+
+// MarkSeen marks a URL as seen. Returns true if the URL was new,
+// false if it was already seen.
+func (d *Deduplicator) MarkSeen(url string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.seen[url]; ok {
+		return false
+	}
+	d.seen[url] = struct{}{}
+	return true
+}
+
+// Size returns the number of unique URLs seen.
+func (d *Deduplicator) Size() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.seen)
+}
+
+// Reset clears all seen URLs.
+func (d *Deduplicator) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.seen = make(map[string]struct{})
+}

--- a/pkg/frontier/filter.go
+++ b/pkg/frontier/filter.go
@@ -1,0 +1,64 @@
+package frontier
+
+import (
+	"regexp"
+	"sync"
+)
+
+// FilterRule defines a URL filtering rule.
+type FilterRule struct {
+	Pattern *regexp.Regexp
+	Allow   bool // true = allow, false = deny
+}
+
+// Filter evaluates URLs against a set of allow/deny rules.
+// Rules are evaluated in order; the first match wins.
+// If no rules match, the URL is allowed by default.
+type Filter struct {
+	mu    sync.RWMutex
+	rules []FilterRule
+}
+
+// NewFilter creates a new URL filter with no rules.
+func NewFilter() *Filter {
+	return &Filter{}
+}
+
+// AddAllowRule adds a pattern that explicitly allows matching URLs.
+func (f *Filter) AddAllowRule(pattern string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.rules = append(f.rules, FilterRule{Pattern: re, Allow: true})
+	f.mu.Unlock()
+	return nil
+}
+
+// AddDenyRule adds a pattern that blocks matching URLs.
+func (f *Filter) AddDenyRule(pattern string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.rules = append(f.rules, FilterRule{Pattern: re, Allow: false})
+	f.mu.Unlock()
+	return nil
+}
+
+// IsAllowed returns true if the URL passes the filter rules.
+// Rules are evaluated in order; the first match determines the result.
+// If no rules match, the URL is allowed.
+func (f *Filter) IsAllowed(url string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	for _, rule := range f.rules {
+		if rule.Pattern.MatchString(url) {
+			return rule.Allow
+		}
+	}
+	return true // default allow
+}

--- a/pkg/frontier/frontier.go
+++ b/pkg/frontier/frontier.go
@@ -1,0 +1,43 @@
+package frontier
+
+import (
+	"context"
+	"time"
+)
+
+// Priority represents the crawl priority of a URL.
+// Lower values indicate higher priority.
+type Priority int
+
+const (
+	PriorityCritical Priority = 0
+	PriorityHigh     Priority = 1
+	PriorityNormal   Priority = 2
+	PriorityLow      Priority = 3
+)
+
+// URLEntry represents a single URL to be crawled, along with scheduling metadata.
+type URLEntry struct {
+	URL          string
+	Priority     Priority
+	Depth        int
+	Metadata     map[string]string
+	DiscoveredAt time.Time
+}
+
+// Frontier manages URL scheduling for the crawler.
+// It determines which URLs are crawled and in what order.
+type Frontier interface {
+	// Add enqueues a URL entry for crawling.
+	Add(entry *URLEntry) error
+
+	// Next returns the next URL to crawl, blocking until one is available
+	// or the context is cancelled.
+	Next(ctx context.Context) (*URLEntry, error)
+
+	// Size returns the number of URLs currently queued.
+	Size() int64
+
+	// Close releases resources held by the frontier.
+	Close() error
+}

--- a/pkg/frontier/frontier_test.go
+++ b/pkg/frontier/frontier_test.go
@@ -1,0 +1,403 @@
+package frontier
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestFrontier() *MemoryFrontier {
+	return NewMemoryFrontier(Config{CrawlDelay: 0})
+}
+
+func mustAdd(t *testing.T, f Frontier, entry *URLEntry) {
+	t.Helper()
+	if err := f.Add(entry); err != nil {
+		t.Fatalf("Add(%q) error = %v", entry.URL, err)
+	}
+}
+
+func mustNext(t *testing.T, f Frontier, ctx context.Context) *URLEntry {
+	t.Helper()
+	entry, err := f.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next() error = %v", err)
+	}
+	return entry
+}
+
+// --- Priority Queue Tests ---
+
+func TestPriorityQueue_Ordering(t *testing.T) {
+	f := newTestFrontier()
+	ctx := context.Background()
+	now := time.Now()
+
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/low", Priority: PriorityLow, DiscoveredAt: now})
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/critical", Priority: PriorityCritical, DiscoveredAt: now})
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/high", Priority: PriorityHigh, DiscoveredAt: now})
+
+	// Should come out in priority order: critical, high, low.
+	e1 := mustNext(t, f, ctx)
+	if e1.Priority != PriorityCritical {
+		t.Errorf("first = %d, want PriorityCritical(%d)", e1.Priority, PriorityCritical)
+	}
+	e2 := mustNext(t, f, ctx)
+	if e2.Priority != PriorityHigh {
+		t.Errorf("second = %d, want PriorityHigh(%d)", e2.Priority, PriorityHigh)
+	}
+	e3 := mustNext(t, f, ctx)
+	if e3.Priority != PriorityLow {
+		t.Errorf("third = %d, want PriorityLow(%d)", e3.Priority, PriorityLow)
+	}
+}
+
+func TestPriorityQueue_FIFOWithinSamePriority(t *testing.T) {
+	f := newTestFrontier()
+	ctx := context.Background()
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Second)
+	t3 := t2.Add(time.Second)
+
+	mustAdd(t, f, &URLEntry{URL: "http://a.com", Priority: PriorityNormal, DiscoveredAt: t1})
+	mustAdd(t, f, &URLEntry{URL: "http://b.com", Priority: PriorityNormal, DiscoveredAt: t2})
+	mustAdd(t, f, &URLEntry{URL: "http://c.com", Priority: PriorityNormal, DiscoveredAt: t3})
+
+	e1 := mustNext(t, f, ctx)
+	e2 := mustNext(t, f, ctx)
+	e3 := mustNext(t, f, ctx)
+
+	if e1.URL != "http://a.com" || e2.URL != "http://b.com" || e3.URL != "http://c.com" {
+		t.Errorf("FIFO order broken: got %s, %s, %s", e1.URL, e2.URL, e3.URL)
+	}
+}
+
+// --- Deduplication Tests ---
+
+func TestDedup_RejectsDuplicate(t *testing.T) {
+	f := newTestFrontier()
+
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/page"})
+	err := f.Add(&URLEntry{URL: "http://example.com/page"})
+	if err != ErrDuplicate {
+		t.Errorf("duplicate Add error = %v, want ErrDuplicate", err)
+	}
+
+	if f.Size() != 1 {
+		t.Errorf("Size = %d, want 1", f.Size())
+	}
+}
+
+func TestDedup_CanonicalizationDedup(t *testing.T) {
+	f := newTestFrontier()
+
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/page/"})
+	err := f.Add(&URLEntry{URL: "http://EXAMPLE.COM/page"})
+	if err != ErrDuplicate {
+		t.Errorf("canonical duplicate error = %v, want ErrDuplicate", err)
+	}
+}
+
+func TestDedup_Standalone(t *testing.T) {
+	d := NewDeduplicator()
+
+	if d.IsSeen("http://example.com") {
+		t.Error("should not be seen initially")
+	}
+
+	if !d.MarkSeen("http://example.com") {
+		t.Error("first MarkSeen should return true")
+	}
+
+	if d.MarkSeen("http://example.com") {
+		t.Error("second MarkSeen should return false")
+	}
+
+	if d.Size() != 1 {
+		t.Errorf("Size = %d, want 1", d.Size())
+	}
+
+	d.Reset()
+	if d.Size() != 0 {
+		t.Errorf("Size after Reset = %d, want 0", d.Size())
+	}
+}
+
+// --- Canonicalization Tests ---
+
+func TestCanonicalize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"HTTP://EXAMPLE.COM/path", "http://example.com/path"},
+		{"http://example.com:80/path", "http://example.com/path"},
+		{"https://example.com:443/path", "https://example.com/path"},
+		{"http://example.com:8080/path", "http://example.com:8080/path"},
+		{"http://example.com/path/", "http://example.com/path"},
+		{"http://example.com/", "http://example.com/"},
+		{"http://example.com/path#fragment", "http://example.com/path"},
+		{"http://example.com/path?b=2&a=1", "http://example.com/path?a=1&b=2"},
+		{"http://example.com/path?a=2&a=1", "http://example.com/path?a=1&a=2"},
+	}
+
+	for _, tt := range tests {
+		got := Canonicalize(tt.input)
+		if got != tt.want {
+			t.Errorf("Canonicalize(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- Filter Tests ---
+
+func TestFilter_AllowDenyRules(t *testing.T) {
+	fl := NewFilter()
+	if err := fl.AddDenyRule(`\.pdf$`); err != nil {
+		t.Fatal(err)
+	}
+	if err := fl.AddAllowRule(`^https://allowed\.com`); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"http://example.com/page", true},      // no rule matches, default allow
+		{"http://example.com/file.pdf", false}, // denied by .pdf rule
+		{"https://allowed.com/file.pdf", true}, // allow rule matches first (if added first)
+	}
+
+	// Re-create with order: allow first, deny second.
+	fl = NewFilter()
+	if err := fl.AddAllowRule(`^https://allowed\.com`); err != nil {
+		t.Fatal(err)
+	}
+	if err := fl.AddDenyRule(`\.pdf$`); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range tests {
+		got := fl.IsAllowed(tt.url)
+		if got != tt.want {
+			t.Errorf("IsAllowed(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestFilter_FrontierIntegration(t *testing.T) {
+	f := newTestFrontier()
+	if err := f.Filter().AddDenyRule(`/blocked`); err != nil {
+		t.Fatal(err)
+	}
+
+	err := f.Add(&URLEntry{URL: "http://example.com/blocked/page"})
+	if err != ErrFiltered {
+		t.Errorf("filtered Add error = %v, want ErrFiltered", err)
+	}
+
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/allowed"})
+	if f.Size() != 1 {
+		t.Errorf("Size = %d, want 1", f.Size())
+	}
+}
+
+// --- Frontier Lifecycle Tests ---
+
+func TestFrontier_Size(t *testing.T) {
+	f := newTestFrontier()
+	ctx := context.Background()
+
+	if f.Size() != 0 {
+		t.Errorf("initial Size = %d, want 0", f.Size())
+	}
+
+	mustAdd(t, f, &URLEntry{URL: "http://a.com"})
+	mustAdd(t, f, &URLEntry{URL: "http://b.com"})
+
+	if f.Size() != 2 {
+		t.Errorf("Size = %d, want 2", f.Size())
+	}
+
+	mustNext(t, f, ctx)
+	if f.Size() != 1 {
+		t.Errorf("Size after Next = %d, want 1", f.Size())
+	}
+}
+
+func TestFrontier_Close(t *testing.T) {
+	f := newTestFrontier()
+
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	err := f.Add(&URLEntry{URL: "http://example.com"})
+	if err != ErrClosed {
+		t.Errorf("Add after Close = %v, want ErrClosed", err)
+	}
+
+	_, err = f.Next(context.Background())
+	if err != ErrClosed {
+		t.Errorf("Next after Close = %v, want ErrClosed", err)
+	}
+}
+
+func TestFrontier_NextBlocksUntilAdd(t *testing.T) {
+	f := newTestFrontier()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var got *URLEntry
+	done := make(chan struct{})
+	go func() {
+		var err error
+		got, err = f.Next(ctx)
+		if err != nil {
+			t.Errorf("Next() error = %v", err)
+		}
+		close(done)
+	}()
+
+	// Small delay to ensure Next is blocking.
+	time.Sleep(50 * time.Millisecond)
+
+	mustAdd(t, f, &URLEntry{URL: "http://example.com"})
+
+	select {
+	case <-done:
+		if got == nil || got.URL != "http://example.com" {
+			t.Errorf("Next() returned %v, want http://example.com", got)
+		}
+	case <-ctx.Done():
+		t.Fatal("Next() did not unblock after Add")
+	}
+}
+
+func TestFrontier_NextCancelledContext(t *testing.T) {
+	f := newTestFrontier()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := f.Next(ctx)
+	if err != context.Canceled {
+		t.Errorf("Next() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFrontier_NilEntry(t *testing.T) {
+	f := newTestFrontier()
+	if err := f.Add(nil); err != ErrNilEntry {
+		t.Errorf("Add(nil) error = %v, want ErrNilEntry", err)
+	}
+}
+
+func TestFrontier_EmptyURL(t *testing.T) {
+	f := newTestFrontier()
+	if err := f.Add(&URLEntry{URL: ""}); err != ErrEmptyURL {
+		t.Errorf("Add(empty) error = %v, want ErrEmptyURL", err)
+	}
+}
+
+// --- Concurrency Test ---
+
+func TestFrontier_ConcurrentAddAndNext(t *testing.T) {
+	f := newTestFrontier()
+	ctx := context.Background()
+
+	const n = 100
+
+	// Add all items first.
+	for i := 0; i < n; i++ {
+		mustAdd(t, f, &URLEntry{
+			URL:      "http://example.com/" + itoa(i),
+			Priority: PriorityNormal,
+		})
+	}
+
+	// Consume with multiple goroutines.
+	var consumed sync.WaitGroup
+	consumed.Add(n)
+
+	for j := 0; j < 4; j++ {
+		go func() {
+			for {
+				_, err := f.Next(ctx)
+				if err != nil {
+					return
+				}
+				consumed.Done()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		consumed.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All items consumed.
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for all items to be consumed")
+	}
+
+	if f.Size() != 0 {
+		t.Errorf("Size after consuming all = %d, want 0", f.Size())
+	}
+}
+
+// --- Crawl Delay Test ---
+
+func TestFrontier_CrawlDelay(t *testing.T) {
+	delay := 100 * time.Millisecond
+	f := NewMemoryFrontier(Config{CrawlDelay: delay})
+	ctx := context.Background()
+
+	// Add two URLs from the same domain.
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/a", Priority: PriorityCritical})
+	mustAdd(t, f, &URLEntry{URL: "http://example.com/b", Priority: PriorityCritical})
+
+	start := time.Now()
+	mustNext(t, f, ctx) // First should return immediately.
+	mustNext(t, f, ctx) // Second should wait for crawl delay.
+	elapsed := time.Since(start)
+
+	// Should take at least the crawl delay.
+	if elapsed < delay {
+		t.Errorf("elapsed %v < crawl delay %v", elapsed, delay)
+	}
+}
+
+func TestFrontier_DiscoveredAtAutoSet(t *testing.T) {
+	f := newTestFrontier()
+	ctx := context.Background()
+
+	before := time.Now()
+	mustAdd(t, f, &URLEntry{URL: "http://example.com"})
+	entry := mustNext(t, f, ctx)
+
+	if entry.DiscoveredAt.Before(before) {
+		t.Error("DiscoveredAt should be set automatically")
+	}
+}
+
+// itoa is a simple int-to-string without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/pkg/frontier/memory.go
+++ b/pkg/frontier/memory.go
@@ -1,0 +1,230 @@
+package frontier
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrClosed    = errors.New("frontier: closed")
+	ErrFiltered  = errors.New("frontier: URL filtered")
+	ErrDuplicate = errors.New("frontier: duplicate URL")
+	ErrEmptyURL  = errors.New("frontier: empty URL")
+	ErrNilEntry  = errors.New("frontier: nil entry")
+)
+
+// Config holds configuration for the in-memory frontier.
+type Config struct {
+	// CrawlDelay is the minimum delay between requests to the same domain.
+	// A zero value means no delay. Use DefaultConfig() for sensible defaults.
+	CrawlDelay time.Duration
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		CrawlDelay: time.Second,
+	}
+}
+
+// MemoryFrontier is an in-memory implementation of the Frontier interface.
+// It uses a heap-based priority queue with deduplication and URL filtering.
+type MemoryFrontier struct {
+	cfg    Config
+	pq     *priorityQueue
+	dedup  *Deduplicator
+	filter *Filter
+	mu     sync.Mutex
+	notify chan struct{}
+	size   atomic.Int64
+	closed atomic.Bool
+
+	// Per-domain tracking for politeness.
+	domainLast map[string]time.Time
+	domainMu   sync.Mutex
+}
+
+// NewMemoryFrontier creates an in-memory frontier with the given config.
+func NewMemoryFrontier(cfg Config) *MemoryFrontier {
+	return &MemoryFrontier{
+		cfg:        cfg,
+		pq:         newPriorityQueue(),
+		dedup:      NewDeduplicator(),
+		filter:     NewFilter(),
+		notify:     make(chan struct{}, 1),
+		domainLast: make(map[string]time.Time),
+	}
+}
+
+// Filter returns the URL filter for adding allow/deny rules.
+func (f *MemoryFrontier) Filter() *Filter {
+	return f.filter
+}
+
+// Add enqueues a URL entry. The URL is canonicalized, checked against
+// filters and dedup before being added to the priority queue.
+func (f *MemoryFrontier) Add(entry *URLEntry) error {
+	if entry == nil {
+		return ErrNilEntry
+	}
+	if entry.URL == "" {
+		return ErrEmptyURL
+	}
+	if f.closed.Load() {
+		return ErrClosed
+	}
+
+	// Canonicalize the URL.
+	entry.URL = Canonicalize(entry.URL)
+
+	// Apply filter rules.
+	if !f.filter.IsAllowed(entry.URL) {
+		return ErrFiltered
+	}
+
+	// Deduplicate.
+	if !f.dedup.MarkSeen(entry.URL) {
+		return ErrDuplicate
+	}
+
+	// Set discovery time if not set.
+	if entry.DiscoveredAt.IsZero() {
+		entry.DiscoveredAt = time.Now()
+	}
+
+	f.mu.Lock()
+	heap.Push(f.pq, entry)
+	f.mu.Unlock()
+	f.size.Add(1)
+
+	// Non-blocking notification for waiting consumers.
+	select {
+	case f.notify <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+// Next returns the next URL to crawl. It blocks until a URL is available
+// or the context is cancelled. Per-domain politeness delays are applied.
+func (f *MemoryFrontier) Next(ctx context.Context) (*URLEntry, error) {
+	for {
+		if f.closed.Load() {
+			return nil, ErrClosed
+		}
+
+		f.mu.Lock()
+		if f.pq.Len() > 0 {
+			entry := heap.Pop(f.pq).(*URLEntry)
+			f.mu.Unlock()
+			f.size.Add(-1)
+
+			// Enforce per-domain crawl delay.
+			f.enforceCrawlDelay(ctx, entry.URL)
+
+			return entry, nil
+		}
+		f.mu.Unlock()
+
+		// Wait for notification or context cancellation.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-f.notify:
+			// New item available, loop back to check.
+		}
+	}
+}
+
+// Size returns the number of URLs currently in the queue.
+func (f *MemoryFrontier) Size() int64 {
+	return f.size.Load()
+}
+
+// Close marks the frontier as closed and wakes any waiting consumers.
+func (f *MemoryFrontier) Close() error {
+	f.closed.Store(true)
+	// Wake up any blocked Next() calls.
+	select {
+	case f.notify <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// enforceCrawlDelay sleeps if needed to maintain the minimum delay
+// between requests to the same domain.
+func (f *MemoryFrontier) enforceCrawlDelay(ctx context.Context, rawURL string) {
+	domain := extractDomain(rawURL)
+	if domain == "" {
+		return
+	}
+
+	f.domainMu.Lock()
+	last, ok := f.domainLast[domain]
+	now := time.Now()
+	f.domainLast[domain] = now
+	f.domainMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	elapsed := now.Sub(last)
+	if elapsed >= f.cfg.CrawlDelay {
+		return
+	}
+
+	wait := f.cfg.CrawlDelay - elapsed
+	select {
+	case <-time.After(wait):
+	case <-ctx.Done():
+	}
+}
+
+// extractDomain returns the host portion of a URL.
+func extractDomain(rawURL string) string {
+	// Simple extraction: find "://" then take until next "/" or end.
+	idx := 0
+	if i := len("://"); len(rawURL) > i {
+		if pos := indexOf(rawURL, "://"); pos >= 0 {
+			idx = pos + 3
+		}
+	}
+	end := len(rawURL)
+	for i := idx; i < len(rawURL); i++ {
+		if rawURL[i] == '/' || rawURL[i] == '?' {
+			end = i
+			break
+		}
+	}
+	host := rawURL[idx:end]
+	// Strip port.
+	if colonPos := lastIndexOf(host, ":"); colonPos >= 0 {
+		host = host[:colonPos]
+	}
+	return host
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexOf(s, sub string) int {
+	for i := len(s) - len(sub); i >= 0; i-- {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/frontier/queue.go
+++ b/pkg/frontier/queue.go
@@ -1,0 +1,41 @@
+package frontier
+
+import "container/heap"
+
+// priorityQueue implements heap.Interface for URLEntry items.
+// Lower Priority values are dequeued first. For equal priorities,
+// earlier DiscoveredAt times come first (FIFO within same priority).
+type priorityQueue []*URLEntry
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	if pq[i].Priority != pq[j].Priority {
+		return pq[i].Priority < pq[j].Priority
+	}
+	return pq[i].DiscoveredAt.Before(pq[j].DiscoveredAt)
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *priorityQueue) Push(x any) {
+	*pq = append(*pq, x.(*URLEntry))
+}
+
+func (pq *priorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*pq = old[:n-1]
+	return item
+}
+
+// newPriorityQueue creates an empty priority queue.
+func newPriorityQueue() *priorityQueue {
+	pq := make(priorityQueue, 0)
+	heap.Init(&pq)
+	return &pq
+}


### PR DESCRIPTION
Closes #8

## Summary
- Define `Frontier` interface with `Add`, `Next`, `Size`, `Close` methods
- Implement in-memory `MemoryFrontier` using `container/heap` priority queue with FIFO tie-breaking
- Add URL canonicalization (lowercase scheme/host, remove default ports/fragments, sort query params)
- Add hash-set based URL deduplication with thread-safe access
- Add regex-based URL filter with ordered allow/deny rules (first match wins)
- Support configurable per-domain crawl delay for politeness enforcement

## Test Plan
- [x] 17 unit tests covering: priority ordering, FIFO within same priority, deduplication, canonicalization dedup, standalone dedup, canonicalization rules, filter allow/deny, filter integration, size tracking, close lifecycle, blocking Next, cancelled context, nil/empty entry validation, concurrent add/next, crawl delay enforcement, auto-set DiscoveredAt
- [x] golangci-lint clean
- [x] All existing tests pass (client, crawler, server, frontier)