### PR TITLE
feat(middleware): implement retry middleware with exponential backoff

### DIFF
--- a/pkg/middleware/retry.go
+++ b/pkg/middleware/retry.go
@@ -1,0 +1,160 @@
+package middleware
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// RetryConfig configures the retry middleware behavior.
+type RetryConfig struct {
+	MaxRetries           int
+	InitialBackoff       time.Duration
+	MaxBackoff           time.Duration
+	Multiplier           float64
+	JitterFactor         float64
+	RetryableStatusCodes []int
+}
+
+// DefaultRetryConfig returns a RetryConfig with sensible defaults.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: time.Second,
+		MaxBackoff:     30 * time.Second,
+		Multiplier:     2.0,
+		JitterFactor:   0.1,
+		RetryableStatusCodes: []int{
+			http.StatusTooManyRequests,
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout,
+		},
+	}
+}
+
+// Retry is a middleware that retries failed requests with exponential backoff.
+type Retry struct {
+	cfg RetryConfig
+}
+
+// NewRetry creates a retry middleware with the given config.
+func NewRetry(cfg RetryConfig) *Retry {
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.InitialBackoff <= 0 {
+		cfg.InitialBackoff = time.Second
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 30 * time.Second
+	}
+	if cfg.Multiplier <= 0 {
+		cfg.Multiplier = 2.0
+	}
+	if len(cfg.RetryableStatusCodes) == 0 {
+		cfg.RetryableStatusCodes = DefaultRetryConfig().RetryableStatusCodes
+	}
+	return &Retry{cfg: cfg}
+}
+
+// ProcessRequest implements Middleware. It retries the request if the response
+// has a retryable status code or an error occurred.
+func (r *Retry) ProcessRequest(ctx context.Context, req *Request, next NextFunc) (*Response, error) {
+	var lastResp *Response
+	var lastErr error
+
+	for attempt := 0; attempt <= r.cfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := r.calculateDelay(attempt, lastResp)
+			if err := sleep(ctx, delay); err != nil {
+				return lastResp, err
+			}
+		}
+
+		resp, err := next(ctx, req)
+		if err == nil && !r.isRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+
+		lastResp = resp
+		lastErr = err
+	}
+
+	return lastResp, lastErr
+}
+
+// calculateDelay computes the backoff delay for the given attempt number.
+// It respects the Retry-After header if present.
+func (r *Retry) calculateDelay(attempt int, resp *Response) time.Duration {
+	// Check Retry-After header.
+	if resp != nil && resp.Headers != nil {
+		if ra := resp.Headers["Retry-After"]; ra != "" {
+			if d := parseRetryAfter(ra); d > 0 {
+				return d
+			}
+		}
+	}
+
+	// Exponential backoff: initialBackoff * multiplier^(attempt-1)
+	backoff := float64(r.cfg.InitialBackoff) * math.Pow(r.cfg.Multiplier, float64(attempt-1))
+
+	// Cap at max backoff.
+	if backoff > float64(r.cfg.MaxBackoff) {
+		backoff = float64(r.cfg.MaxBackoff)
+	}
+
+	// Apply jitter: delay ± (delay * jitterFactor)
+	if r.cfg.JitterFactor > 0 {
+		jitter := backoff * r.cfg.JitterFactor
+		backoff += (rand.Float64()*2 - 1) * jitter //nolint:gosec // jitter does not need cryptographic randomness
+	}
+
+	return time.Duration(backoff)
+}
+
+// isRetryableStatus returns true if the status code is in the retryable set.
+func (r *Retry) isRetryableStatus(code int) bool {
+	for _, c := range r.cfg.RetryableStatusCodes {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRetryAfter parses a Retry-After header value.
+// Supports both seconds (e.g., "120") and HTTP-date formats.
+func parseRetryAfter(value string) time.Duration {
+	// Try parsing as seconds.
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+
+	// Try parsing as HTTP-date.
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d > 0 {
+			return d
+		}
+	}
+
+	return 0
+}
+
+// sleep waits for the given duration or until the context is cancelled.
+func sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetry_NoRetryOnSuccess(t *testing.T) {
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		calls.Add(1)
+		return &Response{StatusCode: 200}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 3, InitialBackoff: time.Millisecond}))
+
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("handler called %d times, want 1", calls.Load())
+	}
+}
+
+func TestRetry_RetriesOnServerError(t *testing.T) {
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return &Response{StatusCode: 503}, nil
+		}
+		return &Response{StatusCode: 200}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 3, InitialBackoff: time.Millisecond}))
+
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("handler called %d times, want 3", calls.Load())
+	}
+}
+
+func TestRetry_RetriesOnError(t *testing.T) {
+	var calls atomic.Int32
+	testErr := errors.New("connection refused")
+
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return nil, testErr
+		}
+		return &Response{StatusCode: 200}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 3, InitialBackoff: time.Millisecond}))
+
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("handler called %d times, want 3", calls.Load())
+	}
+}
+
+func TestRetry_MaxRetriesExhausted(t *testing.T) {
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		calls.Add(1)
+		return &Response{StatusCode: 500}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 2, InitialBackoff: time.Millisecond}))
+
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("final StatusCode = %d, want 500", resp.StatusCode)
+	}
+	// 1 initial + 2 retries = 3 total calls.
+	if calls.Load() != 3 {
+		t.Errorf("handler called %d times, want 3", calls.Load())
+	}
+}
+
+func TestRetry_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			cancel() // Cancel after first attempt.
+		}
+		return &Response{StatusCode: 503}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 5, InitialBackoff: time.Second}))
+
+	_, err := c.Execute(ctx, &Request{URL: "http://example.com"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestRetry_NonRetryableStatusCode(t *testing.T) {
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		calls.Add(1)
+		return &Response{StatusCode: 404}, nil
+	}
+
+	c := NewChain(handler)
+	c.Use(NewRetry(RetryConfig{MaxRetries: 3, InitialBackoff: time.Millisecond}))
+
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("StatusCode = %d, want 404", resp.StatusCode)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("should not retry 404, called %d times", calls.Load())
+	}
+}
+
+func TestRetry_429WithRetryAfterSeconds(t *testing.T) {
+	var calls atomic.Int32
+	handler := func(_ context.Context, _ *Request) (*Response, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return &Response{
+				StatusCode: 429,
+				Headers:    map[string]string{"Retry-After": "1"},
+			}, nil
+		}
+		return &Response{StatusCode: 200}, nil
+	}
+
+	c := NewChain(handler)
+	cfg := RetryConfig{MaxRetries: 2, InitialBackoff: time.Millisecond}
+	c.Use(NewRetry(cfg))
+
+	start := time.Now()
+	resp, err := c.Execute(context.Background(), &Request{URL: "http://example.com"})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	// Should wait approximately 1 second due to Retry-After header.
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("elapsed %v, expected ≥1s due to Retry-After", elapsed)
+	}
+}
+
+func TestRetry_BackoffCalculation(t *testing.T) {
+	r := NewRetry(RetryConfig{
+		InitialBackoff: 100 * time.Millisecond,
+		MaxBackoff:     10 * time.Second,
+		Multiplier:     2.0,
+		JitterFactor:   0, // No jitter for deterministic test.
+	})
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 100 * time.Millisecond},  // 100ms * 2^0
+		{2, 200 * time.Millisecond},  // 100ms * 2^1
+		{3, 400 * time.Millisecond},  // 100ms * 2^2
+		{4, 800 * time.Millisecond},  // 100ms * 2^3
+		{5, 1600 * time.Millisecond}, // 100ms * 2^4
+	}
+
+	for _, tt := range tests {
+		got := r.calculateDelay(tt.attempt, nil)
+		if got != tt.want {
+			t.Errorf("delay(attempt=%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestRetry_MaxBackoffCap(t *testing.T) {
+	r := NewRetry(RetryConfig{
+		InitialBackoff: time.Second,
+		MaxBackoff:     5 * time.Second,
+		Multiplier:     10.0,
+		JitterFactor:   0,
+	})
+
+	got := r.calculateDelay(3, nil) // 1s * 10^2 = 100s, capped at 5s.
+	if got != 5*time.Second {
+		t.Errorf("delay = %v, want 5s (capped)", got)
+	}
+}
+
+func TestRetry_DefaultConfig(t *testing.T) {
+	cfg := DefaultRetryConfig()
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	}
+	if cfg.InitialBackoff != time.Second {
+		t.Errorf("InitialBackoff = %v, want 1s", cfg.InitialBackoff)
+	}
+	if cfg.MaxBackoff != 30*time.Second {
+		t.Errorf("MaxBackoff = %v, want 30s", cfg.MaxBackoff)
+	}
+	if len(cfg.RetryableStatusCodes) != 5 {
+		t.Errorf("RetryableStatusCodes len = %d, want 5", len(cfg.RetryableStatusCodes))
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool // true if duration should be > 0
+	}{
+		{"120", true},
+		{"0", false},
+		{"invalid", false},
+	}
+
+	for _, tt := range tests {
+		got := parseRetryAfter(tt.value)
+		if tt.want && got <= 0 {
+			t.Errorf("parseRetryAfter(%q) = %v, want > 0", tt.value, got)
+		}
+		if !tt.want && got > 0 {
+			t.Errorf("parseRetryAfter(%q) = %v, want 0", tt.value, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #11

## Summary
- Implement `Retry` middleware with configurable exponential backoff and jitter
- Support `Retry-After` header parsing (seconds and HTTP-date formats)
- Configurable retryable status codes (default: 429, 500, 502, 503, 504)
- Context-aware: stops retrying when context is cancelled
- Backoff formula: `min(initialBackoff * multiplier^attempt, maxBackoff) ± jitter`

## Test Plan
- [x] 11 unit tests: no retry on success, retry on server error, retry on error, max retries exhausted, context cancellation, non-retryable status, 429 with Retry-After, backoff calculation (deterministic), max backoff cap, default config, parseRetryAfter
- [x] golangci-lint clean
- [x] All existing tests pass