### PR TITLE
feat(storage): implement file-based storage with JSON and CSV export

### DIFF
--- a/pkg/storage/csv.go
+++ b/pkg/storage/csv.go
@@ -1,0 +1,159 @@
+package storage
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// CSVConfig configures the CSV file storage.
+type CSVConfig struct {
+	// Path is the output file path. Required.
+	Path string
+
+	// Delimiter is the field separator. Default: comma.
+	Delimiter rune
+
+	// Columns defines the CSV header columns. If empty, columns are
+	// auto-detected from the first batch of items.
+	Columns []string
+}
+
+// CSVStorage writes crawled items to a CSV file.
+// Nested data maps are flattened with dot notation (e.g., "data.title").
+type CSVStorage struct {
+	cfg     CSVConfig
+	mu      sync.Mutex
+	file    *os.File
+	writer  *csv.Writer
+	columns []string
+	wrote   bool
+}
+
+// NewCSVStorage creates a new CSVStorage instance.
+func NewCSVStorage(cfg CSVConfig) *CSVStorage {
+	return &CSVStorage{cfg: cfg}
+}
+
+// Init opens the output file and prepares the CSV writer.
+func (c *CSVStorage) Init(config map[string]any) error {
+	if p, ok := config["path"].(string); ok && p != "" {
+		c.cfg.Path = p
+	}
+	if c.cfg.Path == "" {
+		return fmt.Errorf("csv storage: path is required")
+	}
+
+	file, err := os.OpenFile(c.cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //nolint:gosec // user-specified output file
+	if err != nil {
+		return fmt.Errorf("csv storage: open %s: %w", c.cfg.Path, err)
+	}
+
+	c.file = file
+	c.writer = csv.NewWriter(file)
+	if c.cfg.Delimiter != 0 {
+		c.writer.Comma = c.cfg.Delimiter
+	}
+	c.columns = c.cfg.Columns
+
+	return nil
+}
+
+// Store writes items as CSV rows. On the first call, if no columns are
+// configured, they are auto-detected from the items.
+func (c *CSVStorage) Store(_ context.Context, items []Item) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.file == nil {
+		return fmt.Errorf("csv storage: not initialized")
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Auto-detect columns from first batch if not configured.
+	if len(c.columns) == 0 {
+		c.columns = detectColumns(items[0])
+	}
+
+	// Write header on first Store call.
+	if !c.wrote {
+		if err := c.writer.Write(c.columns); err != nil {
+			return fmt.Errorf("csv storage: write header: %w", err)
+		}
+		c.wrote = true
+	}
+
+	for _, item := range items {
+		flat := flattenItem(item)
+		row := make([]string, len(c.columns))
+		for i, col := range c.columns {
+			row[i] = flat[col]
+		}
+		if err := c.writer.Write(row); err != nil {
+			return fmt.Errorf("csv storage: write row: %w", err)
+		}
+	}
+
+	c.writer.Flush()
+	return c.writer.Error()
+}
+
+// Close flushes and closes the CSV file.
+func (c *CSVStorage) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.file == nil {
+		return nil
+	}
+
+	c.writer.Flush()
+	err := c.file.Close()
+	c.file = nil
+	c.writer = nil
+	return err
+}
+
+// detectColumns returns sorted column names from an item.
+func detectColumns(item Item) []string {
+	flat := flattenItem(item)
+	cols := make([]string, 0, len(flat))
+	for k := range flat {
+		cols = append(cols, k)
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+// flattenItem converts an Item into a flat key-value map suitable for CSV.
+func flattenItem(item Item) map[string]string {
+	flat := make(map[string]string)
+
+	flat["url"] = item.URL
+	flat["crawled_at"] = item.CrawledAt.Format(time.RFC3339)
+
+	flattenMap(flat, "data", item.Data)
+	flattenMap(flat, "metadata", item.Metadata)
+
+	return flat
+}
+
+// flattenMap recursively flattens a nested map with dot-separated keys.
+func flattenMap(out map[string]string, prefix string, m map[string]any) {
+	for k, v := range m {
+		key := prefix + "." + k
+		switch val := v.(type) {
+		case map[string]any:
+			flattenMap(out, key, val)
+		default:
+			out[key] = fmt.Sprintf("%v", val)
+		}
+	}
+}

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// FileConfig configures the JSON Lines file storage.
+type FileConfig struct {
+	// Path is the output file path. Required.
+	Path string
+
+	// Pretty enables indented JSON output instead of JSON Lines.
+	Pretty bool
+}
+
+// FileStorage writes crawled items to a file in JSON Lines format.
+// It is safe for concurrent use.
+type FileStorage struct {
+	cfg  FileConfig
+	mu   sync.Mutex
+	file *os.File
+	enc  *json.Encoder
+}
+
+// NewFileStorage creates a new FileStorage instance.
+func NewFileStorage(cfg FileConfig) *FileStorage {
+	return &FileStorage{cfg: cfg}
+}
+
+// Init opens the output file for append-mode writing.
+func (f *FileStorage) Init(config map[string]any) error {
+	if p, ok := config["path"].(string); ok && p != "" {
+		f.cfg.Path = p
+	}
+	if f.cfg.Path == "" {
+		return fmt.Errorf("file storage: path is required")
+	}
+
+	file, err := os.OpenFile(f.cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // user-specified output file
+	if err != nil {
+		return fmt.Errorf("file storage: open %s: %w", f.cfg.Path, err)
+	}
+
+	f.file = file
+	f.enc = json.NewEncoder(file)
+	if f.cfg.Pretty {
+		f.enc.SetIndent("", "  ")
+	}
+
+	return nil
+}
+
+// Store writes items to the file in JSON Lines format (one JSON object per line).
+func (f *FileStorage) Store(_ context.Context, items []Item) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.file == nil {
+		return fmt.Errorf("file storage: not initialized")
+	}
+
+	for _, item := range items {
+		if err := f.enc.Encode(item); err != nil {
+			return fmt.Errorf("file storage: encode item: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Close flushes and closes the file.
+func (f *FileStorage) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.file == nil {
+		return nil
+	}
+
+	err := f.file.Close()
+	f.file = nil
+	f.enc = nil
+	return err
+}

--- a/pkg/storage/plugin.go
+++ b/pkg/storage/plugin.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// Plugin defines the interface for storing crawled data.
+// Implementations handle the specifics of each storage backend.
+type Plugin interface {
+	// Init initializes the storage backend with the given configuration.
+	Init(config map[string]any) error
+
+	// Store writes items to the storage backend.
+	Store(ctx context.Context, items []Item) error
+
+	// Close flushes pending data and releases resources.
+	Close() error
+}
+
+// Item represents a single crawled page and its extracted data.
+type Item struct {
+	URL       string         `json:"url"`
+	Data      map[string]any `json:"data,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	CrawledAt time.Time      `json:"crawled_at"`
+}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,0 +1,465 @@
+package storage
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var testTime = time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+func testItems() []Item {
+	return []Item{
+		{
+			URL:       "https://example.com/page1",
+			Data:      map[string]any{"title": "Page 1", "score": 42},
+			Metadata:  map[string]any{"depth": 1},
+			CrawledAt: testTime,
+		},
+		{
+			URL:       "https://example.com/page2",
+			Data:      map[string]any{"title": "Page 2"},
+			Metadata:  map[string]any{"depth": 2},
+			CrawledAt: testTime.Add(time.Minute),
+		},
+	}
+}
+
+// --- FileStorage (JSON Lines) tests ---
+
+func TestFileStorage_JSONLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.jsonl")
+
+	fs := NewFileStorage(FileConfig{Path: path})
+	if err := fs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	items := testItems()
+	if err := fs.Store(context.Background(), items); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSON lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var item Item
+		if err := json.Unmarshal([]byte(line), &item); err != nil {
+			t.Errorf("line %d: invalid JSON: %v", i, err)
+		}
+		if item.URL != items[i].URL {
+			t.Errorf("line %d: expected URL %q, got %q", i, items[i].URL, item.URL)
+		}
+	}
+}
+
+func TestFileStorage_Pretty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.json")
+
+	fs := NewFileStorage(FileConfig{Path: path, Pretty: true})
+	if err := fs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := fs.Store(context.Background(), testItems()[:1]); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+
+	// Pretty output should contain indentation
+	if !strings.Contains(string(data), "  ") {
+		t.Error("expected indented JSON output")
+	}
+}
+
+func TestFileStorage_Append(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.jsonl")
+
+	// Write first batch
+	fs := NewFileStorage(FileConfig{Path: path})
+	if err := fs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := fs.Store(context.Background(), testItems()[:1]); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Write second batch (should append)
+	fs2 := NewFileStorage(FileConfig{Path: path})
+	if err := fs2.Init(nil); err != nil {
+		t.Fatalf("init2: %v", err)
+	}
+	if err := fs2.Store(context.Background(), testItems()[1:]); err != nil {
+		t.Fatalf("store2: %v", err)
+	}
+	if err := fs2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines after append, got %d", len(lines))
+	}
+}
+
+func TestFileStorage_ConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "concurrent.jsonl")
+
+	fs := NewFileStorage(FileConfig{Path: path})
+	if err := fs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = fs.Store(context.Background(), testItems()[:1])
+		}()
+	}
+	wg.Wait()
+
+	if err := fs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 10 {
+		t.Errorf("expected 10 lines from concurrent writes, got %d", len(lines))
+	}
+}
+
+func TestFileStorage_InitPathFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "from_config.jsonl")
+
+	fs := NewFileStorage(FileConfig{})
+	if err := fs.Init(map[string]any{"path": path}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file to be created: %v", err)
+	}
+}
+
+func TestFileStorage_InitNoPath(t *testing.T) {
+	fs := NewFileStorage(FileConfig{})
+	if err := fs.Init(nil); err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestFileStorage_StoreNotInitialized(t *testing.T) {
+	fs := NewFileStorage(FileConfig{Path: "unused"})
+	err := fs.Store(context.Background(), testItems())
+	if err == nil {
+		t.Error("expected error for uninitialized storage")
+	}
+}
+
+// --- CSVStorage tests ---
+
+func TestCSVStorage_BasicOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.csv")
+
+	cs := NewCSVStorage(CSVConfig{
+		Path:    path,
+		Columns: []string{"url", "data.title", "crawled_at"},
+	})
+
+	if err := cs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := cs.Store(context.Background(), testItems()); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+
+	// 1 header + 2 data rows
+	if len(records) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(records))
+	}
+
+	// Check header
+	if records[0][0] != "url" || records[0][1] != "data.title" {
+		t.Errorf("unexpected header: %v", records[0])
+	}
+
+	// Check first data row
+	if records[1][0] != "https://example.com/page1" {
+		t.Errorf("expected URL in first row, got %q", records[1][0])
+	}
+	if records[1][1] != "Page 1" {
+		t.Errorf("expected title 'Page 1', got %q", records[1][1])
+	}
+}
+
+func TestCSVStorage_AutoDetectColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auto.csv")
+
+	cs := NewCSVStorage(CSVConfig{Path: path})
+	if err := cs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := cs.Store(context.Background(), testItems()[:1]); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+
+	if len(records) < 2 {
+		t.Fatalf("expected at least header + 1 row, got %d", len(records))
+	}
+
+	// Columns should be sorted and include flattened keys
+	header := records[0]
+	foundURL := false
+	for _, col := range header {
+		if col == "url" {
+			foundURL = true
+		}
+	}
+	if !foundURL {
+		t.Error("expected 'url' in auto-detected columns")
+	}
+}
+
+func TestCSVStorage_CustomDelimiter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tabs.csv")
+
+	cs := NewCSVStorage(CSVConfig{
+		Path:      path,
+		Delimiter: '\t',
+		Columns:   []string{"url", "data.title"},
+	})
+
+	if err := cs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := cs.Store(context.Background(), testItems()[:1]); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if !strings.Contains(string(data), "\t") {
+		t.Error("expected tab-delimited output")
+	}
+}
+
+func TestCSVStorage_NestedData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested.csv")
+
+	items := []Item{
+		{
+			URL: "https://example.com",
+			Data: map[string]any{
+				"meta": map[string]any{
+					"author": "John",
+					"tags":   "go,web",
+				},
+			},
+			CrawledAt: testTime,
+		},
+	}
+
+	cs := NewCSVStorage(CSVConfig{
+		Path:    path,
+		Columns: []string{"url", "data.meta.author", "data.meta.tags"},
+	})
+
+	if err := cs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := cs.Store(context.Background(), items); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(records))
+	}
+
+	if records[1][1] != "John" {
+		t.Errorf("expected author 'John', got %q", records[1][1])
+	}
+}
+
+func TestCSVStorage_InitNoPath(t *testing.T) {
+	cs := NewCSVStorage(CSVConfig{})
+	if err := cs.Init(nil); err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestCSVStorage_ConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "concurrent.csv")
+
+	cs := NewCSVStorage(CSVConfig{
+		Path:    path,
+		Columns: []string{"url"},
+	})
+
+	if err := cs.Init(nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cs.Store(context.Background(), testItems()[:1])
+		}()
+	}
+	wg.Wait()
+
+	if err := cs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+
+	// 1 header + 10 data rows
+	if len(records) != 11 {
+		t.Errorf("expected 11 rows (1 header + 10 data), got %d", len(records))
+	}
+}
+
+// --- flattenItem tests ---
+
+func TestFlattenItem(t *testing.T) {
+	item := Item{
+		URL: "https://example.com",
+		Data: map[string]any{
+			"title": "Hello",
+			"nested": map[string]any{
+				"key": "value",
+			},
+		},
+		CrawledAt: testTime,
+	}
+
+	flat := flattenItem(item)
+
+	if flat["url"] != "https://example.com" {
+		t.Errorf("expected url, got %q", flat["url"])
+	}
+	if flat["data.title"] != "Hello" {
+		t.Errorf("expected data.title='Hello', got %q", flat["data.title"])
+	}
+	if flat["data.nested.key"] != "value" {
+		t.Errorf("expected data.nested.key='value', got %q", flat["data.nested.key"])
+	}
+}


### PR DESCRIPTION
Closes #18

## Summary
- Add `storage.Plugin` interface with `Init/Store/Close` for pluggable storage backends
- Implement `FileStorage`: JSON Lines writer with append mode, pretty-print option, thread-safe writes
- Implement `CSVStorage`: CSV export with dot-notation flattening for nested maps, configurable delimiter, auto-detected columns
- 14 unit tests covering all storage functionality

## Storage Backends

| Backend | Format | Features |
|---------|--------|----------|
| `FileStorage` | JSON Lines (`.jsonl`) | Append mode, pretty-print, concurrent-safe |
| `CSVStorage` | CSV | Flat key mapping, custom delimiter, auto-detect columns |

## Test Plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes (14 new tests, all green)
- [ ] Verify JSON Lines output: one valid JSON object per line
- [ ] Verify CSV output: header + data rows with flattened nested keys