### PR TITLE
feat(testing): set up testing infrastructure with helpers and integration tests

### DIFF
--- a/internal/testutil/assertions.go
+++ b/internal/testutil/assertions.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+// AssertContains fails the test if s does not contain substr.
+func AssertContains(t *testing.T, s, substr string) {
+	t.Helper()
+	if !strings.Contains(s, substr) {
+		t.Errorf("expected string to contain %q, got %q", substr, s)
+	}
+}
+
+// AssertNoError fails the test if err is not nil.
+func AssertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// AssertError fails the test if err is nil.
+func AssertError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+}
+
+// AssertEqual fails the test if got != want.
+func AssertEqual[T comparable](t *testing.T, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/testutil/benchmark_test.go
+++ b/internal/testutil/benchmark_test.go
@@ -1,0 +1,146 @@
+package testutil
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+	"github.com/kcenon/web_crawler/pkg/frontier"
+	"github.com/kcenon/web_crawler/pkg/storage"
+)
+
+func BenchmarkCrawlSinglePage(b *testing.B) {
+	srv := NewHTTPServer(
+		Page{Path: "/", Body: "<html><body>Hello</body></html>"},
+	)
+	defer srv.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		c := crawler.NewEngine(crawler.Config{
+			MaxDepth:    1,
+			MaxPages:    1,
+			WorkerCount: 1,
+		})
+
+		done := make(chan struct{})
+		c.OnResponse(func(_ *crawler.CrawlResponse) {
+			close(done)
+		})
+
+		_ = c.AddURL(srv.URL + "/")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = c.Start(ctx)
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+
+		_ = c.Wait()
+		cancel()
+	}
+}
+
+func BenchmarkFrontierAddAndNext(b *testing.B) {
+	b.ReportAllocs()
+
+	f := frontier.NewMemoryFrontier(frontier.Config{})
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.Add(&frontier.URLEntry{URL: "https://example.com/page", Priority: 0})
+		_, _ = f.Next(ctx)
+	}
+}
+
+func BenchmarkStorageFileWrite(b *testing.B) {
+	dir := b.TempDir()
+
+	fs := storage.NewFileStorage(storage.FileConfig{
+		Path: dir + "/bench.jsonl",
+	})
+	_ = fs.Init(nil)
+	defer fs.Close()
+
+	items := []storage.Item{
+		{
+			URL:       "https://example.com/page",
+			Data:      map[string]any{"title": "Test Page"},
+			CrawledAt: time.Now(),
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = fs.Store(context.Background(), items)
+	}
+}
+
+func BenchmarkStorageCSVWrite(b *testing.B) {
+	dir := b.TempDir()
+
+	cs := storage.NewCSVStorage(storage.CSVConfig{
+		Path:    dir + "/bench.csv",
+		Columns: []string{"url", "data.title", "crawled_at"},
+	})
+	_ = cs.Init(nil)
+	defer cs.Close()
+
+	items := []storage.Item{
+		{
+			URL:       "https://example.com/page",
+			Data:      map[string]any{"title": "Test Page"},
+			CrawledAt: time.Now(),
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = cs.Store(context.Background(), items)
+	}
+}
+
+func BenchmarkCrawlConcurrent(b *testing.B) {
+	srv := NewHTTPServer(
+		Page{Path: "/", Body: "<html><body>Hello</body></html>"},
+	)
+	defer srv.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		c := crawler.NewEngine(crawler.Config{
+			MaxDepth:    1,
+			MaxPages:    10,
+			WorkerCount: 4,
+		})
+
+		var wg sync.WaitGroup
+		wg.Add(4)
+		c.OnResponse(func(_ *crawler.CrawlResponse) {
+			wg.Done()
+		})
+
+		for j := 0; j < 4; j++ {
+			_ = c.AddURL(srv.URL + "/")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = c.Start(ctx)
+		wg.Wait()
+		_ = c.Wait()
+		cancel()
+	}
+}

--- a/internal/testutil/fixtures/data.json
+++ b/internal/testutil/fixtures/data.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {"id": 1, "title": "First Item", "url": "https://example.com/1"},
+    {"id": 2, "title": "Second Item", "url": "https://example.com/2"},
+    {"id": 3, "title": "Third Item", "url": "https://example.com/3"}
+  ],
+  "meta": {
+    "total": 3,
+    "page": 1
+  }
+}

--- a/internal/testutil/fixtures/links.html
+++ b/internal/testutil/fixtures/links.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Links Page</title></head>
+<body>
+    <nav>
+        <a href="/page1">Page 1</a>
+        <a href="/page2">Page 2</a>
+        <a href="https://external.example.com/other">External Link</a>
+    </nav>
+    <main>
+        <a href="/page3?ref=main">Page 3 with params</a>
+        <a href="#section">Anchor link</a>
+        <a href="mailto:test@example.com">Email</a>
+    </main>
+</body>
+</html>

--- a/internal/testutil/fixtures/simple.html
+++ b/internal/testutil/fixtures/simple.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Page</title>
+    <meta name="description" content="A simple test page for crawler testing">
+</head>
+<body>
+    <h1>Welcome to the Test Page</h1>
+    <p>This is a paragraph with some content.</p>
+    <a href="/about">About Us</a>
+    <a href="/contact">Contact</a>
+    <div class="article">
+        <h2>Article Title</h2>
+        <p class="content">Article body text goes here.</p>
+        <span class="author">John Doe</span>
+    </div>
+</body>
+</html>

--- a/internal/testutil/httpserver.go
+++ b/internal/testutil/httpserver.go
@@ -1,0 +1,95 @@
+// Package testutil provides test helpers for the web crawler project.
+package testutil
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+// Page represents a mock web page served by the test HTTP server.
+type Page struct {
+	// Path is the URL path (e.g., "/about").
+	Path string
+
+	// StatusCode is the HTTP response status code. Default: 200.
+	StatusCode int
+
+	// ContentType is the Content-Type header. Default: "text/html".
+	ContentType string
+
+	// Body is the response body content.
+	Body string
+
+	// Headers are additional response headers.
+	Headers map[string]string
+}
+
+// NewHTTPServer creates a test HTTP server that serves the given pages.
+// Pages are matched by exact path. Unmatched paths return 404.
+func NewHTTPServer(pages ...Page) *httptest.Server {
+	mux := http.NewServeMux()
+
+	for _, p := range pages {
+		page := p // capture range variable
+		mux.HandleFunc(page.Path, func(w http.ResponseWriter, _ *http.Request) {
+			for k, v := range page.Headers {
+				w.Header().Set(k, v)
+			}
+
+			ct := page.ContentType
+			if ct == "" {
+				ct = "text/html"
+			}
+			w.Header().Set("Content-Type", ct)
+
+			status := page.StatusCode
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+
+			fmt.Fprint(w, page.Body)
+		})
+	}
+
+	return httptest.NewServer(mux)
+}
+
+// NewLinkedHTTPServer creates a test server with pages that link to each other,
+// simulating a simple website structure for crawl depth testing.
+func NewLinkedHTTPServer() *httptest.Server {
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>
+			<h1>Home</h1>
+			<a href="%s/page1">Page 1</a>
+			<a href="%s/page2">Page 2</a>
+		</body></html>`, srv.URL, srv.URL)
+	})
+
+	mux.HandleFunc("/page1", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>
+			<h1>Page 1</h1>
+			<a href="%s/page1/sub">Subpage</a>
+		</body></html>`, srv.URL)
+	})
+
+	mux.HandleFunc("/page1/sub", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>Subpage</h1></body></html>`)
+	})
+
+	mux.HandleFunc("/page2", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>Page 2</h1></body></html>`)
+	})
+
+	srv = httptest.NewServer(mux)
+	return srv
+}

--- a/internal/testutil/httpserver_test.go
+++ b/internal/testutil/httpserver_test.go
@@ -1,0 +1,109 @@
+package testutil
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestNewHTTPServer_ServesPages(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{
+			Path:        "/hello",
+			StatusCode:  200,
+			ContentType: "text/html",
+			Body:        "<h1>Hello</h1>",
+		},
+		Page{
+			Path:        "/json",
+			StatusCode:  200,
+			ContentType: "application/json",
+			Body:        `{"key":"value"}`,
+		},
+	)
+	defer srv.Close()
+
+	// Test HTML page
+	resp, err := http.Get(srv.URL + "/hello")
+	AssertNoError(t, err)
+	defer resp.Body.Close()
+	AssertEqual(t, resp.StatusCode, 200)
+
+	body, _ := io.ReadAll(resp.Body)
+	AssertContains(t, string(body), "<h1>Hello</h1>")
+
+	// Test JSON page
+	resp2, err := http.Get(srv.URL + "/json")
+	AssertNoError(t, err)
+	defer resp2.Body.Close()
+	AssertEqual(t, resp2.StatusCode, 200)
+
+	body2, _ := io.ReadAll(resp2.Body)
+	AssertContains(t, string(body2), `"key":"value"`)
+}
+
+func TestNewHTTPServer_CustomStatus(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{Path: "/error", StatusCode: 500, Body: "Internal Server Error"},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/error")
+	AssertNoError(t, err)
+	defer resp.Body.Close()
+	AssertEqual(t, resp.StatusCode, 500)
+}
+
+func TestNewHTTPServer_DefaultValues(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{Path: "/default", Body: "Hello"},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/default")
+	AssertNoError(t, err)
+	defer resp.Body.Close()
+
+	AssertEqual(t, resp.StatusCode, 200)
+	ct := resp.Header.Get("Content-Type")
+	AssertContains(t, ct, "text/html")
+}
+
+func TestNewLinkedHTTPServer(t *testing.T) {
+	srv := NewLinkedHTTPServer()
+	defer srv.Close()
+
+	// Test home page has links
+	resp, err := http.Get(srv.URL + "/")
+	AssertNoError(t, err)
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	AssertContains(t, string(body), "Page 1")
+	AssertContains(t, string(body), "Page 2")
+
+	// Test linked page
+	resp2, err := http.Get(srv.URL + "/page1")
+	AssertNoError(t, err)
+	defer resp2.Body.Close()
+	AssertEqual(t, resp2.StatusCode, 200)
+}
+
+func TestNewHTTPServer_CustomHeaders(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{
+			Path: "/headers",
+			Body: "ok",
+			Headers: map[string]string{
+				"X-Custom": "test-value",
+			},
+		},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/headers")
+	AssertNoError(t, err)
+	defer resp.Body.Close()
+
+	AssertEqual(t, resp.Header.Get("X-Custom"), "test-value")
+}

--- a/internal/testutil/integration_test.go
+++ b/internal/testutil/integration_test.go
@@ -1,0 +1,184 @@
+package testutil
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+)
+
+func TestIntegration_CrawlSinglePage(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{
+			Path:        "/",
+			ContentType: "text/html",
+			Body:        "<html><body><h1>Hello World</h1></body></html>",
+		},
+	)
+	defer srv.Close()
+
+	c := crawler.NewEngine(crawler.Config{
+		MaxDepth:    1,
+		MaxPages:    1,
+		WorkerCount: 1,
+	})
+
+	var (
+		mu       sync.Mutex
+		gotURL   string
+		gotCode  int
+		gotBody  int
+		gotError string
+	)
+
+	c.OnResponse(func(resp *crawler.CrawlResponse) {
+		mu.Lock()
+		gotURL = resp.Request.URL
+		gotCode = resp.StatusCode
+		gotBody = len(resp.Body)
+		mu.Unlock()
+	})
+
+	c.OnError(func(_ *crawler.CrawlRequest, err error) {
+		mu.Lock()
+		gotError = err.Error()
+		mu.Unlock()
+	})
+
+	AssertNoError(t, c.AddURL(srv.URL+"/"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	AssertNoError(t, c.Start(ctx))
+	_ = c.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if gotError != "" {
+		t.Fatalf("unexpected crawl error: %s", gotError)
+	}
+	AssertEqual(t, gotURL, srv.URL+"/")
+	AssertEqual(t, gotCode, 200)
+	if gotBody == 0 {
+		t.Error("expected non-empty response body")
+	}
+}
+
+func TestIntegration_CrawlMultiplePages(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{Path: "/a", Body: "Page A"},
+		Page{Path: "/b", Body: "Page B"},
+		Page{Path: "/c", Body: "Page C"},
+	)
+	defer srv.Close()
+
+	c := crawler.NewEngine(crawler.Config{
+		MaxDepth:    1,
+		MaxPages:    10,
+		WorkerCount: 3,
+	})
+
+	var (
+		mu   sync.Mutex
+		urls []string
+	)
+
+	c.OnResponse(func(resp *crawler.CrawlResponse) {
+		mu.Lock()
+		urls = append(urls, resp.Request.URL)
+		mu.Unlock()
+	})
+
+	AssertNoError(t, c.AddURL(srv.URL+"/a"))
+	AssertNoError(t, c.AddURL(srv.URL+"/b"))
+	AssertNoError(t, c.AddURL(srv.URL+"/c"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	AssertNoError(t, c.Start(ctx))
+	_ = c.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	AssertEqual(t, len(urls), 3)
+}
+
+func TestIntegration_CrawlHandlesErrors(t *testing.T) {
+	srv := NewHTTPServer(
+		Page{Path: "/ok", StatusCode: 200, Body: "OK"},
+		Page{Path: "/fail", StatusCode: 500, Body: "Error"},
+	)
+	defer srv.Close()
+
+	c := crawler.NewEngine(crawler.Config{
+		MaxDepth:    1,
+		MaxPages:    10,
+		WorkerCount: 2,
+	})
+
+	var (
+		mu        sync.Mutex
+		responses int
+	)
+
+	c.OnResponse(func(_ *crawler.CrawlResponse) {
+		mu.Lock()
+		responses++
+		mu.Unlock()
+	})
+
+	AssertNoError(t, c.AddURL(srv.URL+"/ok"))
+	AssertNoError(t, c.AddURL(srv.URL+"/fail"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	AssertNoError(t, c.Start(ctx))
+	_ = c.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Both pages return responses (500 is still a response, not an error)
+	AssertEqual(t, responses, 2)
+}
+
+func TestIntegration_CrawlWithHeaders(t *testing.T) {
+	var gotUA string
+	srv := NewHTTPServer(
+		Page{Path: "/", Body: "OK"},
+	)
+	// Replace handler to capture user-agent
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		origHandler.ServeHTTP(w, r)
+	})
+	defer srv.Close()
+
+	c := crawler.NewEngine(crawler.Config{
+		MaxDepth:    1,
+		MaxPages:    1,
+		WorkerCount: 1,
+		UserAgent:   "test-crawler/1.0",
+	})
+
+	c.OnResponse(func(_ *crawler.CrawlResponse) {})
+
+	AssertNoError(t, c.AddURL(srv.URL+"/"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	AssertNoError(t, c.Start(ctx))
+	_ = c.Wait()
+
+	AssertEqual(t, gotUA, "test-crawler/1.0")
+}


### PR DESCRIPTION
Closes #19

## Summary
- Add `internal/testutil/httpserver.go`: mock HTTP server builder with page-level configuration
- Add `internal/testutil/assertions.go`: generic typed test helpers (AssertEqual, AssertContains, etc.)
- Add `internal/testutil/fixtures/`: HTML and JSON test fixtures
- 4 integration tests: end-to-end crawl with mock server (single page, multiple pages, errors, headers)
- 5 benchmark tests: crawler throughput, frontier ops, storage write performance

## Test Helpers

| Helper | Description |
|--------|-------------|
| `NewHTTPServer(pages...)` | Creates mock server with configured responses |
| `NewLinkedHTTPServer()` | Creates linked-page server for depth testing |
| `AssertEqual[T]` | Generic typed equality check |
| `AssertContains` | String containment check |
| `AssertNoError/AssertError` | Error presence checks |

## Test Plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes (9 new tests, all green)
- [x] Integration tests validate end-to-end crawl flow