### PR TITLE
docs: add API documentation, usage examples, and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to Web Crawler SDK
+
+Thank you for your interest in contributing! This guide covers the development setup and workflow.
+
+## Development Setup
+
+### Prerequisites
+
+- Go 1.21+
+- Python 3.10+ (for Python SDK)
+- [buf](https://buf.build/) (for Protocol Buffers)
+- [golangci-lint](https://golangci-lint.run/) v1.64+
+
+### Clone and Build
+
+```bash
+git clone https://github.com/kcenon/web_crawler.git
+cd web_crawler
+go build ./...
+```
+
+### Generate Protocol Buffers
+
+```bash
+cd api/proto
+buf generate
+```
+
+### Run Tests
+
+```bash
+# Go tests
+go test ./...
+
+# With coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+
+# Python tests
+cd python
+pip install -e ".[dev]"
+pytest
+```
+
+### Run Linter
+
+```bash
+golangci-lint run ./...
+```
+
+## Project Structure
+
+```
+web_crawler/
+├── api/proto/          # Protocol Buffer definitions
+├── cmd/crawler/        # CLI application
+│   └── cmd/            # Cobra commands (crawl, run, server, init)
+├── examples/           # Usage examples
+├── internal/
+│   └── testutil/       # Test helpers, fixtures, benchmarks
+├── pkg/
+│   ├── client/         # HTTP client with connection pooling
+│   ├── crawler/        # Core crawler engine and Service
+│   ├── extractor/      # CSS selector data extraction
+│   ├── frontier/       # URL frontier with priority queue
+│   ├── middleware/      # Middleware chain (retry, rate limit, robots.txt)
+│   ├── observability/  # Logging and Prometheus metrics
+│   ├── server/         # gRPC server
+│   └── storage/        # File storage (JSON Lines, CSV)
+└── python/             # Python SDK
+    └── crawler/        # Client library
+```
+
+## Workflow
+
+1. Check open issues or create a new one
+2. Fork and create a feature branch: `feat/issue-<number>-<description>`
+3. Make changes following existing code style
+4. Ensure `go build ./...`, `golangci-lint run ./...`, and `go test ./...` pass
+5. Commit with [Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): description`
+6. Create a PR with `Closes #<issue-number>`
+
+## Code Style
+
+- Follow existing patterns in the codebase
+- All code, comments, and documentation in English
+- No AI/Claude attribution in commits or PRs
+- Use `log/slog` for structured logging
+- Interfaces define contracts, implementations are package-private where possible
+
+## Commit Messages
+
+Format: `type(scope): description`
+
+| Type | Usage |
+|------|-------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring |
+| `docs` | Documentation |
+| `test` | Tests |
+| `chore` | Build, CI, dependencies |
+
+## Architecture Notes
+
+- **Engine** (`pkg/crawler`): Worker pool with callback-driven processing
+- **Service** (`pkg/crawler`): Multi-tenant management layer for gRPC
+- **Middleware** (`pkg/middleware`): Onion model with `NextFunc` composition
+- **Frontier** (`pkg/frontier`): Heap-based priority queue with dedup and filtering
+- **Storage** (`pkg/storage`): Plugin interface with JSON Lines and CSV implementations

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -1,0 +1,68 @@
+// Package main demonstrates using the middleware chain with the web crawler SDK.
+//
+// This example shows how to build a middleware chain with rate limiting
+// and retry, then execute requests through it.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/middleware"
+)
+
+func main() {
+	// Terminal handler: simulates an actual HTTP request.
+	handler := func(_ context.Context, req *middleware.Request) (*middleware.Response, error) {
+		fmt.Printf("  -> Executing request: %s\n", req.URL)
+		return &middleware.Response{
+			StatusCode: 200,
+			Body:       []byte("OK"),
+		}, nil
+	}
+
+	// Build middleware chain with rate limiting and retry.
+	chain := middleware.NewChain(handler)
+
+	// Rate limiter: 2 RPS globally, 1 RPS per domain.
+	chain.Use(middleware.NewRateLimit(middleware.RateLimitConfig{
+		GlobalRPS:        2,
+		DefaultDomainRPS: 1,
+		BurstSize:        3,
+	}))
+
+	// Retry: up to 3 attempts with exponential backoff.
+	chain.Use(middleware.NewRetry(middleware.RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+		Multiplier:     2.0,
+		JitterFactor:   0.1,
+	}))
+
+	// Execute requests through the chain.
+	urls := []string{
+		"https://example.com/page1",
+		"https://example.com/page2",
+		"https://example.org/page1",
+	}
+
+	for _, u := range urls {
+		req := &middleware.Request{
+			URL:    u,
+			Method: "GET",
+		}
+
+		fmt.Printf("Processing: %s\n", u)
+		resp, err := chain.Execute(context.Background(), req)
+		if err != nil {
+			log.Printf("Error: %v", err)
+			continue
+		}
+		fmt.Printf("  <- Response: %d (%d bytes)\n\n", resp.StatusCode, len(resp.Body))
+	}
+
+	fmt.Printf("Chain has %d middleware(s)\n", chain.Len())
+}

--- a/examples/storage/main.go
+++ b/examples/storage/main.go
@@ -1,0 +1,77 @@
+// Package main demonstrates crawling with file-based storage output.
+//
+// This example crawls a URL and saves results to both JSON Lines
+// and CSV formats using the storage plugins.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+	"github.com/kcenon/web_crawler/pkg/storage"
+)
+
+func main() {
+	// Set up JSON Lines storage.
+	jsonStore := storage.NewFileStorage(storage.FileConfig{
+		Path: "output/results.jsonl",
+	})
+	if err := jsonStore.Init(nil); err != nil {
+		log.Fatal(err)
+	}
+	defer jsonStore.Close()
+
+	// Set up CSV storage.
+	csvStore := storage.NewCSVStorage(storage.CSVConfig{
+		Path:    "output/results.csv",
+		Columns: []string{"url", "data.title", "data.status", "crawled_at"},
+	})
+	if err := csvStore.Init(nil); err != nil {
+		log.Fatal(err)
+	}
+	defer csvStore.Close()
+
+	// Build the crawler.
+	c, err := crawler.NewBuilder().
+		WithMaxDepth(1).
+		WithMaxPages(10).
+		Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// On each response, store the result.
+	c.OnResponse(func(resp *crawler.CrawlResponse) {
+		item := storage.Item{
+			URL: resp.Request.URL,
+			Data: map[string]any{
+				"title":  fmt.Sprintf("Page at %s", resp.Request.URL),
+				"status": resp.StatusCode,
+				"size":   len(resp.Body),
+			},
+			CrawledAt: time.Now(),
+		}
+
+		_ = jsonStore.Store(context.Background(), []storage.Item{item})
+		_ = csvStore.Store(context.Background(), []storage.Item{item})
+
+		fmt.Printf("Stored: %s [%d]\n", resp.Request.URL, resp.StatusCode)
+	})
+
+	if err := c.AddURL("https://example.com"); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := c.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	_ = c.Wait()
+
+	fmt.Println("\nResults saved to output/results.jsonl and output/results.csv")
+}

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,122 @@
+# Web Crawler Python SDK
+
+Python client library for the Web Crawler gRPC server.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Quick Start
+
+### Synchronous Client
+
+```python
+from crawler import CrawlerClient
+
+with CrawlerClient(host="localhost", port=50051) as client:
+    # Simple crawl
+    result = client.crawl("https://example.com")
+    print(f"Status: {result.status_code}")
+    print(f"Content length: {len(result.content)}")
+
+    # Crawl multiple URLs
+    results = client.crawl_many([
+        "https://example.com",
+        "https://example.org",
+    ])
+    for r in results:
+        print(f"{r.url}: {r.status_code}")
+```
+
+### Async Client
+
+```python
+import asyncio
+from crawler import AsyncCrawlerClient
+
+async def main():
+    async with AsyncCrawlerClient(host="localhost", port=50051) as client:
+        result = await client.crawl("https://example.com")
+        print(f"Status: {result.status_code}")
+
+        # Stream results
+        async for result in client.crawl_stream(["https://example.com"]):
+            print(f"Streamed: {result.url}")
+
+asyncio.run(main())
+```
+
+### Long-Running Crawler
+
+```python
+from crawler import CrawlerClient, CrawlConfig
+
+with CrawlerClient() as client:
+    # Start a managed crawler
+    config = CrawlConfig(max_depth=3, max_pages=100)
+    crawler_id = client.start(config)
+    print(f"Crawler started: {crawler_id}")
+
+    # Add more URLs
+    client.add_urls(crawler_id, ["https://example.com/page2"])
+
+    # Check stats
+    stats = client.stats(crawler_id)
+    print(f"Pages crawled: {stats.pages_crawled}")
+
+    # Stop and get final stats
+    final_stats = client.stop(crawler_id)
+    print(f"Total crawled: {final_stats.pages_crawled}")
+```
+
+## API Reference
+
+### CrawlerClient
+
+| Method | Description |
+|--------|-------------|
+| `crawl(url, **kwargs)` | Crawl a single URL |
+| `crawl_many(urls, **kwargs)` | Crawl multiple URLs |
+| `start(config, crawler_id="")` | Start a managed crawler |
+| `stop(crawler_id)` | Stop a crawler, get final stats |
+| `add_urls(crawler_id, urls)` | Add URLs to running crawler |
+| `stats(crawler_id)` | Get crawler statistics |
+| `close()` | Close the connection |
+
+### AsyncCrawlerClient
+
+Same API as `CrawlerClient` but with `async`/`await` support, plus:
+
+| Method | Description |
+|--------|-------------|
+| `crawl_stream(urls, **kwargs)` | Stream results as they arrive |
+
+### Types
+
+- `CrawlConfig(max_depth, max_pages, respect_robots_txt, urls)`
+- `CrawlResult(url, status_code, content, crawled_at, duration, error)`
+- `CrawlStats(pages_crawled, pages_failed, pages_queued)`
+
+### Exceptions
+
+- `CrawlerError` - Base exception
+- `ConnectionError` - Server unreachable
+- `CrawlError` - Crawl operation failed
+- `NotFoundError` - Crawler not found
+- `AlreadyRunningError` - Crawler already started
+
+## Requirements
+
+- Python 3.10+
+- Running Web Crawler gRPC server
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+mypy crawler/
+ruff check crawler/
+```


### PR DESCRIPTION
Closes #20

## Summary
- Add `examples/middleware/main.go`: middleware chain with rate limiting and retry
- Add `examples/storage/main.go`: crawl with JSON Lines and CSV output
- Add `python/README.md`: Python SDK quick start, API reference, exceptions, dev setup
- Add `CONTRIBUTING.md`: development workflow, project structure, code style, architecture overview

## Test Plan
- [x] `go build ./...` passes (all examples compile)
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes