### PR TITLE
feat(errors): define error type hierarchy and handling strategy

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,222 @@
+// Package errors defines the error type hierarchy for the web crawler SDK.
+//
+// All error types implement the standard error interface and support
+// unwrapping via errors.Is() and errors.As() for programmatic handling.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorCode identifies error categories for programmatic handling.
+// Codes are stable across versions for Python SDK mapping.
+type ErrorCode int
+
+const (
+	CodeUnknown    ErrorCode = 0
+	CodeNetwork    ErrorCode = 1
+	CodeHTTP       ErrorCode = 2
+	CodeExtraction ErrorCode = 3
+	CodeConfig     ErrorCode = 4
+	CodeRobots     ErrorCode = 5
+	CodeRateLimit  ErrorCode = 6
+	CodeTimeout    ErrorCode = 7
+	CodeCancelled  ErrorCode = 8
+)
+
+// CrawlerError is the base error type for all crawler errors.
+type CrawlerError struct {
+	Code    ErrorCode
+	Message string
+	Cause   error
+}
+
+func (e *CrawlerError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+	}
+	return e.Message
+}
+
+func (e *CrawlerError) Unwrap() error {
+	return e.Cause
+}
+
+// NetworkError represents connection, DNS, or transport-level errors.
+type NetworkError struct {
+	CrawlerError
+	URL string
+}
+
+// NewNetworkError creates a NetworkError.
+func NewNetworkError(url string, cause error) *NetworkError {
+	return &NetworkError{
+		CrawlerError: CrawlerError{
+			Code:    CodeNetwork,
+			Message: fmt.Sprintf("network error for %s", url),
+			Cause:   cause,
+		},
+		URL: url,
+	}
+}
+
+// HTTPError represents an HTTP response with an error status code.
+type HTTPError struct {
+	CrawlerError
+	StatusCode int
+	URL        string
+}
+
+// NewHTTPError creates an HTTPError.
+func NewHTTPError(url string, statusCode int) *HTTPError {
+	return &HTTPError{
+		CrawlerError: CrawlerError{
+			Code:    CodeHTTP,
+			Message: fmt.Sprintf("HTTP %d for %s", statusCode, url),
+		},
+		StatusCode: statusCode,
+		URL:        url,
+	}
+}
+
+// ExtractionError represents a failure during data extraction.
+type ExtractionError struct {
+	CrawlerError
+	Selector string
+	URL      string
+}
+
+// NewExtractionError creates an ExtractionError.
+func NewExtractionError(url, selector string, cause error) *ExtractionError {
+	return &ExtractionError{
+		CrawlerError: CrawlerError{
+			Code:    CodeExtraction,
+			Message: fmt.Sprintf("extraction failed for selector %q on %s", selector, url),
+			Cause:   cause,
+		},
+		Selector: selector,
+		URL:      url,
+	}
+}
+
+// ConfigError represents an invalid configuration.
+type ConfigError struct {
+	CrawlerError
+	Field string
+}
+
+// NewConfigError creates a ConfigError.
+func NewConfigError(field, message string) *ConfigError {
+	return &ConfigError{
+		CrawlerError: CrawlerError{
+			Code:    CodeConfig,
+			Message: fmt.Sprintf("config error: %s: %s", field, message),
+		},
+		Field: field,
+	}
+}
+
+// RobotsError represents a URL blocked by robots.txt.
+type RobotsError struct {
+	CrawlerError
+	URL string
+}
+
+// NewRobotsError creates a RobotsError.
+func NewRobotsError(url string) *RobotsError {
+	return &RobotsError{
+		CrawlerError: CrawlerError{
+			Code:    CodeRobots,
+			Message: fmt.Sprintf("blocked by robots.txt: %s", url),
+		},
+		URL: url,
+	}
+}
+
+// RateLimitError represents a rate limit being exceeded.
+type RateLimitError struct {
+	CrawlerError
+	Domain string
+}
+
+// NewRateLimitError creates a RateLimitError.
+func NewRateLimitError(domain string) *RateLimitError {
+	return &RateLimitError{
+		CrawlerError: CrawlerError{
+			Code:    CodeRateLimit,
+			Message: fmt.Sprintf("rate limit exceeded for %s", domain),
+		},
+		Domain: domain,
+	}
+}
+
+// TimeoutError represents a request or operation timeout.
+type TimeoutError struct {
+	CrawlerError
+	URL string
+}
+
+// NewTimeoutError creates a TimeoutError.
+func NewTimeoutError(url string, cause error) *TimeoutError {
+	return &TimeoutError{
+		CrawlerError: CrawlerError{
+			Code:    CodeTimeout,
+			Message: fmt.Sprintf("timeout for %s", url),
+			Cause:   cause,
+		},
+		URL: url,
+	}
+}
+
+// IsRetryable returns true if the error represents a transient condition
+// that may succeed on retry. Network errors, timeouts, rate limits,
+// and 5xx HTTP errors are considered retryable.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var netErr *NetworkError
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var timeoutErr *TimeoutError
+	if errors.As(err, &timeoutErr) {
+		return true
+	}
+
+	var rateLimitErr *RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return true
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 || httpErr.StatusCode == 429
+	}
+
+	return false
+}
+
+// IsTemporary returns true if the error is likely temporary and the
+// operation may succeed later without changes.
+func IsTemporary(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var netErr *NetworkError
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var timeoutErr *TimeoutError
+	if errors.As(err, &timeoutErr) {
+		return true
+	}
+
+	var rateLimitErr *RateLimitError
+	return errors.As(err, &rateLimitErr)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,194 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNetworkError(t *testing.T) {
+	cause := fmt.Errorf("connection refused")
+	err := NewNetworkError("https://example.com", cause)
+
+	if err.Code != CodeNetwork {
+		t.Errorf("expected code %d, got %d", CodeNetwork, err.Code)
+	}
+	if err.URL != "https://example.com" {
+		t.Errorf("expected URL, got %q", err.URL)
+	}
+
+	// Test Error() includes cause
+	msg := err.Error()
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+
+	// Test Unwrap
+	if !errors.Is(err, cause) {
+		t.Error("expected errors.Is to find cause")
+	}
+}
+
+func TestHTTPError(t *testing.T) {
+	err := NewHTTPError("https://example.com/page", 404)
+
+	if err.StatusCode != 404 {
+		t.Errorf("expected status 404, got %d", err.StatusCode)
+	}
+	if err.Code != CodeHTTP {
+		t.Errorf("expected code %d, got %d", CodeHTTP, err.Code)
+	}
+
+	// Test errors.As
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Error("expected errors.As to match HTTPError")
+	}
+}
+
+func TestExtractionError(t *testing.T) {
+	cause := fmt.Errorf("parse error")
+	err := NewExtractionError("https://example.com", "h1.title", cause)
+
+	if err.Selector != "h1.title" {
+		t.Errorf("expected selector, got %q", err.Selector)
+	}
+	if !errors.Is(err, cause) {
+		t.Error("expected errors.Is to find cause")
+	}
+}
+
+func TestConfigError(t *testing.T) {
+	err := NewConfigError("max_depth", "must be positive")
+
+	if err.Field != "max_depth" {
+		t.Errorf("expected field 'max_depth', got %q", err.Field)
+	}
+	if err.Code != CodeConfig {
+		t.Errorf("expected code %d, got %d", CodeConfig, err.Code)
+	}
+}
+
+func TestRobotsError(t *testing.T) {
+	err := NewRobotsError("https://example.com/secret")
+
+	var robotsErr *RobotsError
+	if !errors.As(err, &robotsErr) {
+		t.Error("expected errors.As to match RobotsError")
+	}
+	if robotsErr.URL != "https://example.com/secret" {
+		t.Errorf("expected URL, got %q", robotsErr.URL)
+	}
+}
+
+func TestRateLimitError(t *testing.T) {
+	err := NewRateLimitError("example.com")
+
+	if err.Domain != "example.com" {
+		t.Errorf("expected domain, got %q", err.Domain)
+	}
+}
+
+func TestTimeoutError(t *testing.T) {
+	cause := fmt.Errorf("context deadline exceeded")
+	err := NewTimeoutError("https://example.com", cause)
+
+	if err.URL != "https://example.com" {
+		t.Errorf("expected URL, got %q", err.URL)
+	}
+	if !errors.Is(err, cause) {
+		t.Error("expected errors.Is to find cause")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"network error", NewNetworkError("url", nil), true},
+		{"timeout error", NewTimeoutError("url", nil), true},
+		{"rate limit error", NewRateLimitError("domain"), true},
+		{"HTTP 500", NewHTTPError("url", 500), true},
+		{"HTTP 502", NewHTTPError("url", 502), true},
+		{"HTTP 429", NewHTTPError("url", 429), true},
+		{"HTTP 404", NewHTTPError("url", 404), false},
+		{"HTTP 200", NewHTTPError("url", 200), false},
+		{"config error", NewConfigError("field", "msg"), false},
+		{"robots error", NewRobotsError("url"), false},
+		{"extraction error", NewExtractionError("url", "sel", nil), false},
+		{"plain error", fmt.Errorf("some error"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsRetryable(tc.err)
+			if got != tc.expected {
+				t.Errorf("IsRetryable(%v) = %v, want %v", tc.err, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsTemporary(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"network error", NewNetworkError("url", nil), true},
+		{"timeout error", NewTimeoutError("url", nil), true},
+		{"rate limit error", NewRateLimitError("domain"), true},
+		{"HTTP error", NewHTTPError("url", 500), false},
+		{"config error", NewConfigError("field", "msg"), false},
+		{"robots error", NewRobotsError("url"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsTemporary(tc.err)
+			if got != tc.expected {
+				t.Errorf("IsTemporary(%v) = %v, want %v", tc.err, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestWrappedErrorChain(t *testing.T) {
+	rootCause := fmt.Errorf("DNS resolution failed")
+	netErr := NewNetworkError("https://example.com", rootCause)
+	wrapped := fmt.Errorf("crawl operation: %w", netErr)
+
+	// Should find NetworkError through wrapping
+	var found *NetworkError
+	if !errors.As(wrapped, &found) {
+		t.Error("expected errors.As to find NetworkError in wrapped chain")
+	}
+
+	// Should find root cause
+	if !errors.Is(wrapped, rootCause) {
+		t.Error("expected errors.Is to find root cause in wrapped chain")
+	}
+
+	// IsRetryable should work through wrapping
+	if !IsRetryable(wrapped) {
+		t.Error("expected wrapped NetworkError to be retryable")
+	}
+}
+
+func TestCrawlerError_NoCause(t *testing.T) {
+	err := &CrawlerError{
+		Code:    CodeUnknown,
+		Message: "something went wrong",
+	}
+
+	if err.Error() != "something went wrong" {
+		t.Errorf("unexpected message: %q", err.Error())
+	}
+	if err.Unwrap() != nil {
+		t.Error("expected nil cause")
+	}
+}


### PR DESCRIPTION
Closes #21

## Summary
- Add `pkg/errors/` with comprehensive error type hierarchy
- 8 error types: `CrawlerError` (base), `NetworkError`, `HTTPError`, `ExtractionError`, `ConfigError`, `RobotsError`, `RateLimitError`, `TimeoutError`
- Stable `ErrorCode` enum for cross-SDK mapping (Go ↔ Python)
- `IsRetryable()` and `IsTemporary()` classification helpers
- Full `errors.Is()`/`errors.As()`/`Unwrap()` support

## Error Classification

| Error Type | Retryable | Temporary |
|-----------|-----------|-----------|
| NetworkError | Yes | Yes |
| TimeoutError | Yes | Yes |
| RateLimitError | Yes | Yes |
| HTTPError (5xx/429) | Yes | No |
| HTTPError (4xx) | No | No |
| ConfigError | No | No |
| RobotsError | No | No |
| ExtractionError | No | No |

## Test Plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes (11 test functions, 30+ cases)