### PR TITLE
feat(client): implement HTTP and SOCKS5 proxy support

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -79,9 +79,14 @@ type Client struct {
 func New(cfg Config, opts ...Option) (*Client, error) {
 	cfg = cfg.withDefaults()
 
+	pool, err := newPool(cfg.Transport)
+	if err != nil {
+		return nil, fmt.Errorf("create connection pool: %w", err)
+	}
+
 	c := &Client{
 		cfg:  cfg,
-		pool: newPool(cfg.Transport),
+		pool: pool,
 	}
 
 	for _, opt := range opts {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -365,20 +365,29 @@ func TestTransportConfig_Defaults(t *testing.T) {
 
 func TestTransportConfig_HTTP2Toggle(t *testing.T) {
 	// HTTP/2 enabled by default (DisableHTTP2 = false)
-	transport := buildTransport(TransportConfig{}.withDefaults())
+	transport, err := buildTransport(TransportConfig{}.withDefaults())
+	if err != nil {
+		t.Fatalf("buildTransport error: %v", err)
+	}
 	if !transport.ForceAttemptHTTP2 {
 		t.Error("ForceAttemptHTTP2 should be true by default")
 	}
 
 	// HTTP/2 disabled explicitly
-	transport = buildTransport(TransportConfig{DisableHTTP2: true}.withDefaults())
+	transport, err = buildTransport(TransportConfig{DisableHTTP2: true}.withDefaults())
+	if err != nil {
+		t.Fatalf("buildTransport error: %v", err)
+	}
 	if transport.ForceAttemptHTTP2 {
 		t.Error("ForceAttemptHTTP2 should be false when DisableHTTP2 is set")
 	}
 }
 
 func TestTransportConfig_TLS12Minimum(t *testing.T) {
-	transport := buildTransport(TransportConfig{}.withDefaults())
+	transport, err := buildTransport(TransportConfig{}.withDefaults())
+	if err != nil {
+		t.Fatalf("buildTransport error: %v", err)
+	}
 	if transport.TLSClientConfig.MinVersion != 0x0303 { // tls.VersionTLS12
 		t.Errorf("TLS MinVersion = %#x, want TLS 1.2 (%#x)", transport.TLSClientConfig.MinVersion, 0x0303)
 	}

--- a/pkg/client/pool.go
+++ b/pkg/client/pool.go
@@ -17,8 +17,12 @@ type Pool struct {
 }
 
 // newPool creates a new Pool from the given TransportConfig.
-func newPool(cfg TransportConfig) *Pool {
-	return &Pool{transport: buildTransport(cfg)}
+func newPool(cfg TransportConfig) (*Pool, error) {
+	t, err := buildTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Pool{transport: t}, nil
 }
 
 // stats returns current pool statistics.

--- a/pkg/client/proxy.go
+++ b/pkg/client/proxy.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// ProxyConfig configures proxy server settings for the HTTP transport.
+type ProxyConfig struct {
+	// URL is the proxy server address. Supported schemes:
+	// http://, https://, socks5://
+	URL string
+
+	// Username for proxy authentication (optional).
+	Username string
+
+	// Password for proxy authentication (optional).
+	Password string
+}
+
+// applyProxy configures the transport to route requests through the proxy.
+// For HTTP/HTTPS proxies it sets Transport.Proxy; for SOCKS5 it replaces
+// the DialContext with a SOCKS5-aware dialer.
+func applyProxy(transport *http.Transport, cfg ProxyConfig, dialTimeout time.Duration) error {
+	if cfg.URL == "" {
+		return nil
+	}
+
+	proxyURL, err := url.Parse(cfg.URL)
+	if err != nil {
+		return fmt.Errorf("parse proxy URL: %w", err)
+	}
+
+	// Embed credentials in the URL if provided.
+	if cfg.Username != "" {
+		proxyURL.User = url.UserPassword(cfg.Username, cfg.Password)
+	}
+
+	switch proxyURL.Scheme {
+	case "http", "https":
+		transport.Proxy = http.ProxyURL(proxyURL)
+
+	case "socks5":
+		dialer, err := newSOCKS5Dialer(proxyURL, dialTimeout)
+		if err != nil {
+			return fmt.Errorf("create SOCKS5 dialer: %w", err)
+		}
+		transport.DialContext = dialer
+
+	default:
+		return fmt.Errorf("unsupported proxy scheme: %q (use http, https, or socks5)", proxyURL.Scheme)
+	}
+
+	return nil
+}
+
+// newSOCKS5Dialer creates a DialContext function that routes connections
+// through a SOCKS5 proxy server.
+func newSOCKS5Dialer(proxyURL *url.URL, dialTimeout time.Duration) (func(ctx context.Context, network, addr string) (net.Conn, error), error) {
+	var auth *proxy.Auth
+	if proxyURL.User != nil {
+		pass, _ := proxyURL.User.Password()
+		auth = &proxy.Auth{
+			User:     proxyURL.User.Username(),
+			Password: pass,
+		}
+	}
+
+	forward := &net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: 30 * time.Second,
+	}
+
+	socksDialer, err := proxy.SOCKS5("tcp", proxyURL.Host, auth, forward)
+	if err != nil {
+		return nil, err
+	}
+
+	// proxy.SOCKS5 returns a proxy.Dialer. Check if it also implements
+	// proxy.ContextDialer for context-aware dialing.
+	if ctxDialer, ok := socksDialer.(proxy.ContextDialer); ok {
+		return ctxDialer.DialContext, nil
+	}
+
+	// Fallback: wrap the basic Dialer.
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return socksDialer.Dial(network, addr)
+	}, nil
+}

--- a/pkg/client/proxy_test.go
+++ b/pkg/client/proxy_test.go
@@ -1,0 +1,234 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyProxy_Empty(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{}, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transport.Proxy != nil {
+		t.Error("expected nil Proxy for empty config")
+	}
+}
+
+func TestApplyProxy_HTTPProxy(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{
+		URL: "http://proxy.example.com:8080",
+	}, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected Proxy to be set")
+	}
+
+	// Verify the proxy function returns the correct URL.
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy func error: %v", err)
+	}
+	if proxyURL.Host != "proxy.example.com:8080" {
+		t.Errorf("expected proxy host, got %q", proxyURL.Host)
+	}
+}
+
+func TestApplyProxy_HTTPProxyWithAuth(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{
+		URL:      "http://proxy.example.com:8080",
+		Username: "user",
+		Password: "pass",
+	}, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	proxyURL, _ := transport.Proxy(req)
+	if proxyURL.User == nil {
+		t.Fatal("expected user info in proxy URL")
+	}
+	if proxyURL.User.Username() != "user" {
+		t.Errorf("expected username 'user', got %q", proxyURL.User.Username())
+	}
+	pass, _ := proxyURL.User.Password()
+	if pass != "pass" {
+		t.Errorf("expected password 'pass', got %q", pass)
+	}
+}
+
+func TestApplyProxy_SOCKS5(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{
+		URL: "socks5://localhost:1080",
+	}, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transport.DialContext == nil {
+		t.Error("expected DialContext to be set for SOCKS5")
+	}
+}
+
+func TestApplyProxy_UnsupportedScheme(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{
+		URL: "ftp://proxy.example.com",
+	}, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+	if !strings.Contains(err.Error(), "unsupported proxy scheme") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestApplyProxy_InvalidURL(t *testing.T) {
+	transport := &http.Transport{}
+	err := applyProxy(transport, ProxyConfig{
+		URL: "://invalid",
+	}, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestBuildTransport_WithProxy(t *testing.T) {
+	cfg := TransportConfig{
+		Proxy: ProxyConfig{
+			URL: "http://proxy.example.com:8080",
+		},
+	}.withDefaults()
+
+	transport, err := buildTransport(cfg)
+	if err != nil {
+		t.Fatalf("buildTransport error: %v", err)
+	}
+	if transport.Proxy == nil {
+		t.Error("expected proxy to be configured")
+	}
+}
+
+func TestBuildTransport_WithInvalidProxy(t *testing.T) {
+	cfg := TransportConfig{
+		Proxy: ProxyConfig{
+			URL: "ftp://invalid-scheme",
+		},
+	}.withDefaults()
+
+	_, err := buildTransport(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid proxy scheme")
+	}
+}
+
+func TestHTTPProxy_Integration(t *testing.T) {
+	// Create a target server.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello from target"))
+	}))
+	defer target.Close()
+
+	// Create a simple HTTP CONNECT proxy.
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			// CONNECT tunnel for HTTPS.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijack not supported", http.StatusInternalServerError)
+				return
+			}
+			clientConn, _, err := hijacker.Hijack()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer clientConn.Close()
+
+			targetConn, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
+			if err != nil {
+				return
+			}
+			defer targetConn.Close()
+
+			_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+			go func() { _, _ = io.Copy(targetConn, clientConn) }()
+			_, _ = io.Copy(clientConn, targetConn)
+			return
+		}
+
+		// Forward non-CONNECT requests (plain HTTP proxy).
+		resp, err := http.DefaultTransport.RoundTrip(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}))
+	defer proxyServer.Close()
+
+	proxyURL, _ := url.Parse(proxyServer.URL)
+
+	// Create client with proxy.
+	c, err := New(Config{
+		Transport: TransportConfig{
+			Proxy: ProxyConfig{URL: proxyURL.String()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer c.Close()
+
+	resp, err := c.Do(context.Background(), &Request{
+		URL:    target.URL,
+		Method: "GET",
+	})
+	if err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+	if string(resp.Body) != "hello from target" {
+		t.Errorf("expected body 'hello from target', got %q", string(resp.Body))
+	}
+}
+
+func TestProxyConfig_Defaults(t *testing.T) {
+	// ProxyConfig with empty URL should not affect transport.
+	cfg := TransportConfig{
+		Proxy: ProxyConfig{},
+	}.withDefaults()
+
+	transport, err := buildTransport(cfg)
+	if err != nil {
+		t.Fatalf("buildTransport error: %v", err)
+	}
+	if transport.Proxy != nil {
+		t.Error("expected nil proxy for empty config")
+	}
+}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -45,6 +45,9 @@ type TransportConfig struct {
 	// DisableCompression, if true, prevents requesting gzip/deflate
 	// encoding. Compression is enabled by default.
 	DisableCompression bool
+
+	// Proxy configures an optional proxy server for all requests.
+	Proxy ProxyConfig
 }
 
 func (c TransportConfig) withDefaults() TransportConfig {
@@ -70,8 +73,8 @@ func (c TransportConfig) withDefaults() TransportConfig {
 }
 
 // buildTransport creates an *http.Transport from the configuration.
-func buildTransport(cfg TransportConfig) *http.Transport {
-	return &http.Transport{
+func buildTransport(cfg TransportConfig) (*http.Transport, error) {
+	t := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   cfg.DialTimeout,
 			KeepAlive: 30 * time.Second,
@@ -88,4 +91,10 @@ func buildTransport(cfg TransportConfig) *http.Transport {
 		ForceAttemptHTTP2:     !cfg.DisableHTTP2,
 		DisableCompression:    cfg.DisableCompression,
 	}
+
+	if err := applyProxy(t, cfg.Proxy, cfg.DialTimeout); err != nil {
+		return nil, err
+	}
+
+	return t, nil
 }

--- a/pkg/crawler/builder.go
+++ b/pkg/crawler/builder.go
@@ -1,6 +1,10 @@
 package crawler
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/kcenon/web_crawler/pkg/client"
+)
 
 // Builder provides a fluent API for constructing a Crawler instance.
 type Builder struct {
@@ -39,6 +43,22 @@ func (b *Builder) WithWorkerCount(count int) *Builder {
 // WithUserAgent sets the default User-Agent header.
 func (b *Builder) WithUserAgent(ua string) *Builder {
 	b.cfg.UserAgent = ua
+	return b
+}
+
+// WithProxy configures an HTTP or SOCKS5 proxy for all requests.
+func (b *Builder) WithProxy(proxyURL string) *Builder {
+	b.cfg.Client.Transport.Proxy = client.ProxyConfig{URL: proxyURL}
+	return b
+}
+
+// WithProxyAuth configures an authenticated proxy.
+func (b *Builder) WithProxyAuth(proxyURL, username, password string) *Builder {
+	b.cfg.Client.Transport.Proxy = client.ProxyConfig{
+		URL:      proxyURL,
+		Username: username,
+		Password: password,
+	}
 	return b
 }
 


### PR DESCRIPTION
Closes #7

## Summary
- Add `ProxyConfig` struct supporting HTTP, HTTPS, and SOCKS5 proxy schemes with optional authentication
- HTTP/HTTPS proxies configured via `Transport.Proxy`, SOCKS5 proxies via custom `DialContext` using `golang.org/x/net/proxy`
- Add `WithProxy()` and `WithProxyAuth()` fluent builder methods for crawler-level proxy configuration

## Changes

### New: `pkg/client/proxy.go`
- `ProxyConfig` struct with URL, Username, Password fields
- `applyProxy()` routes to HTTP or SOCKS5 setup based on URL scheme
- `newSOCKS5Dialer()` creates context-aware SOCKS5 dialer with authentication
- Clear error messages for unsupported schemes and invalid URLs

### Modified: `pkg/client/transport.go`
- Add `Proxy ProxyConfig` field to `TransportConfig`
- `buildTransport()` now returns error to propagate proxy config errors

### Modified: `pkg/client/pool.go`, `client.go`
- Propagate error from `buildTransport()` through `newPool()` → `New()`

### Modified: `pkg/crawler/builder.go`
- Add `WithProxy(url)` and `WithProxyAuth(url, user, pass)` builder methods

## Test Plan
- [ ] `go test ./pkg/client/... -v` — 28 tests including:
  - Empty proxy config (no-op)
  - HTTP proxy setup and URL verification
  - HTTP proxy with authentication credentials
  - SOCKS5 proxy dialer creation
  - Unsupported scheme error handling
  - Invalid URL error handling
  - Transport build with proxy
  - Transport build with invalid proxy
  - HTTP proxy integration test (mock proxy server)
  - Empty proxy config defaults
- [ ] `go test ./...` — All existing tests still pass
- [ ] `golangci-lint run ./...` — No lint issues