### PR TITLE
feat(ci): add performance regression benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,126 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate protobuf code
+        run: buf generate
+        working-directory: api/proto
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Restore baseline benchmark results
+        if: github.event_name == 'pull_request'
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: bench-baseline.txt
+          key: bench-baseline-${{ github.event.pull_request.base.sha }}
+          restore-keys: bench-baseline-
+
+      - name: Run benchmarks
+        run: |
+          go test -run='^$' -bench=. -benchmem -count=3 -benchtime=1s \
+            ./pkg/client/... \
+            ./pkg/crawler/... \
+            ./pkg/frontier/... \
+            ./pkg/middleware/... \
+            ./internal/testutil/... \
+            2>/dev/null | tee bench-current.txt
+
+      - name: Prepare and cache baseline (on main push)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: cp bench-current.txt bench-baseline.txt
+
+      - name: Save baseline to cache (on main push)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: bench-baseline.txt
+          key: bench-baseline-${{ github.sha }}
+
+      - name: Compare benchmarks
+        if: github.event_name == 'pull_request' && steps.cache-restore.outputs.cache-hit == 'true'
+        id: benchstat
+        run: |
+          benchstat bench-baseline.txt bench-current.txt | tee bench-delta.txt
+          {
+            echo "result<<BENCHSTAT_EOF"
+            cat bench-delta.txt
+            echo "BENCHSTAT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post benchmark results as PR comment
+        if: github.event_name == 'pull_request' && steps.cache-restore.outputs.cache-hit == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = `${{ steps.benchstat.outputs.result }}`;
+            const body = [
+              "## Benchmark Results",
+              "",
+              "Comparison against `main` baseline (`benchstat`):",
+              "",
+              "```",
+              result,
+              "```",
+              "",
+              "> `~` = no significant change &nbsp; `+N%` = regression &nbsp; `-N%` = improvement",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = "## Benchmark Results";
+            const existing = comments.find(
+              (c) => c.user.type === "Bot" && c.body.startsWith(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+      - name: Upload benchmark results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ github.sha }}
+          path: bench-current.txt
+          retention-days: 90


### PR DESCRIPTION
## What

Add `.github/workflows/benchmark.yml` — a GitHub Actions job that runs Go benchmarks on every push to `main` and on every PR targeting `main`.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `.github/workflows/benchmark.yml` — new benchmark CI job

## Why

### Problem Solved
The benchmark suite was added in PR #65, but there was no CI job to detect performance regressions. A regression can silently slip through review without automated comparison.

### Related Issues
- Closes #68 (feat(ci): add performance regression testing to CI pipeline)
- Part of #26 (Epic: Performance optimization and benchmarking)

## Who

### Reviewers
@kcenon

## When

### Urgency
- [x] Normal

### Target Release
v1.0.0 (Phase 2)

## Where

### Files Changed
| File | Type |
|------|------|
| `.github/workflows/benchmark.yml` | New CI workflow |

### Packages Benchmarked
- `pkg/client` — `BenchmarkDo`, `BenchmarkDo_Parallel`
- `pkg/crawler` — `BenchmarkEngine_Throughput`, `BenchmarkEngine_WorkerScaling`
- `pkg/frontier` — `BenchmarkFrontier_Add`, `BenchmarkFrontier_AddNext`
- `pkg/middleware` — `BenchmarkChain_Execute`
- `internal/testutil` — `BenchmarkCrawlSinglePage`, `BenchmarkCrawlConcurrent`, `BenchmarkStorageFileWrite`, `BenchmarkStorageCSVWrite`

## How

### Implementation Details

**On push to `main`:**
1. Run `go test -bench=. -benchmem -count=3 -benchtime=1s` across all packages
2. Cache results under key `bench-baseline-<commit-sha>` via `actions/cache`
3. Upload results as artifact (90-day retention)

**On pull request:**
1. Restore latest baseline from cache (keyed to `base.sha` of the PR)
2. Run the same benchmark command on the PR branch
3. Run `benchstat baseline current` and capture the comparison table
4. Post/update a PR comment with the delta table

**Comment format:**
```
## Benchmark Results

Comparison against `main` baseline (`benchstat`):

goos: linux/goarch: amd64
...
BenchmarkFoo       3.20ns ± 2%   3.18ns ± 1%   ~  (p=0.423 n=3)
BenchmarkBar       4.10ns ± 1%   5.20ns ± 2%  +26.8% (p=0.003 n=3)

~ = no significant change  +N% = regression  -N% = improvement
```

### Testing Done
- [x] Verified all benchmark packages compile: `go build ./pkg/client/... ./pkg/crawler/... ./pkg/frontier/... ./pkg/middleware/... ./internal/testutil/...`
- [x] Smoke-tested frontier benchmarks locally: `BenchmarkFrontier_Add-14: 438.9 ns/op, 421 B/op, 5 allocs/op`

### Breaking Changes
None — new workflow only.