### PR TITLE
perf(frontier): use read-before-write in Deduplicator.MarkSeen

### DIFF
--- a/pkg/frontier/dedup.go
+++ b/pkg/frontier/dedup.go
@@ -26,7 +26,22 @@ func (d *Deduplicator) IsSeen(url string) bool {
 
 // MarkSeen marks a URL as seen. Returns true if the URL was new,
 // false if it was already seen.
+//
+// Uses a read-before-write pattern: duplicate URLs (the common case in a
+// running crawl) are detected under a shared read lock without blocking
+// concurrent readers or other writers. Only genuinely new URLs escalate to
+// an exclusive write lock, with a re-check to guard against a concurrent
+// insert that may have occurred between the read unlock and write lock.
 func (d *Deduplicator) MarkSeen(url string) bool {
+	// Fast path: check under read lock (concurrent with other readers).
+	d.mu.RLock()
+	_, ok := d.seen[url]
+	d.mu.RUnlock()
+	if ok {
+		return false
+	}
+
+	// Slow path: URL appears new — acquire write lock and re-check.
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.seen[url]; ok {

--- a/pkg/frontier/frontier_test.go
+++ b/pkg/frontier/frontier_test.go
@@ -126,6 +126,43 @@ func TestDedup_Standalone(t *testing.T) {
 	}
 }
 
+func TestDedup_ConcurrentMarkSeen(t *testing.T) {
+	const (
+		goroutines = 20
+		urls       = 50
+	)
+	d := NewDeduplicator(urls)
+
+	// Each goroutine tries to mark the same set of URLs.
+	// Exactly `urls` of the total attempts should succeed (return true).
+	results := make(chan bool, goroutines*urls)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < urls; i++ {
+				results <- d.MarkSeen(fmt.Sprintf("http://example.com/%d", i))
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	newCount := 0
+	for r := range results {
+		if r {
+			newCount++
+		}
+	}
+	if newCount != urls {
+		t.Errorf("new URL count = %d, want %d (each URL should be new exactly once)", newCount, urls)
+	}
+	if d.Size() != urls {
+		t.Errorf("Size = %d, want %d", d.Size(), urls)
+	}
+}
+
 func TestMemoryFrontier_InitialCapacity(t *testing.T) {
 	const n = 1000
 	f := NewMemoryFrontier(Config{InitialCapacity: n})


### PR DESCRIPTION
## What

Replace the unconditional exclusive write lock in `Deduplicator.MarkSeen` with a double-checked locking pattern. Duplicate URLs (the common case in a running crawl) are now detected under a shared read lock without serialising concurrent callers.

### Change Type
- [x] Feature (performance improvement — no interface change)

### Affected Components
- `pkg/frontier/dedup.go` — `MarkSeen` implementation
- `pkg/frontier/frontier_test.go` — new concurrent test

## Why

### Problem Solved
`MarkSeen` previously acquired an exclusive `sync.Mutex` write lock on every call. In a crawl that has been running for some time, the vast majority of discovered URLs are duplicates. All worker goroutines calling `Add()` were serialised on this single write lock even when they only needed to read-check the set.

### Related Issues
- Closes #72
- Part of #26 (Epic: Performance optimization and benchmarking — "Optimize frontier operations for high throughput")

## Who

### Reviewers
@kcenon

## When

### Urgency
- [x] Normal

### Target Release
v1.0.0 (Phase 2)

## Where

### Files Changed
| File | Change |
|------|--------|
| `pkg/frontier/dedup.go` | Replace write-lock-always with read-then-write pattern |
| `pkg/frontier/frontier_test.go` | Add `TestDedup_ConcurrentMarkSeen` |

## How

### Implementation Details

```go
// Before
func (d *Deduplicator) MarkSeen(url string) bool {
    d.mu.Lock()                         // write lock on every call
    defer d.mu.Unlock()
    if _, ok := d.seen[url]; ok { return false }
    d.seen[url] = struct{}{}
    return true
}

// After
func (d *Deduplicator) MarkSeen(url string) bool {
    d.mu.RLock()                        // shared read lock for fast duplicate check
    _, ok := d.seen[url]
    d.mu.RUnlock()
    if ok { return false }

    d.mu.Lock()                         // write lock only for new URLs
    defer d.mu.Unlock()
    if _, ok := d.seen[url]; ok { return false }  // re-check after lock upgrade
    d.seen[url] = struct{}{}
    return true
}
```

The re-check after `Lock()` guards against a concurrent insert that may have occurred in the window between `RUnlock()` and `Lock()`.

### Testing Done
- [x] All existing `pkg/frontier/...` tests pass
- [x] New test `TestDedup_ConcurrentMarkSeen`: 20 goroutines × 50 URLs with full overlap; asserts exactly 50 `true` returns (each URL new exactly once) — passes under `go test -race`
- [x] Build verified

### Breaking Changes
None — same method signature and semantics, only implementation changed.