### PR TITLE
feat(middleware): implement User-Agent rotation middleware

### DIFF
--- a/pkg/middleware/useragent.go
+++ b/pkg/middleware/useragent.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"context"
+	"hash/fnv"
+	"math/rand/v2"
+	"sync/atomic"
+)
+
+// Rotation mode constants for UserAgentConfig.
+const (
+	RotationRoundRobin = "round-robin" // Cycle through agents in order (default).
+	RotationRandom     = "random"      // Pick an agent at random each request.
+	RotationPerDomain  = "per-domain"  // Always use the same agent for a given host.
+)
+
+// DefaultUserAgents is a pool of realistic browser User-Agent strings covering
+// major browsers and operating systems to blend in with normal web traffic.
+var DefaultUserAgents = []string{
+	// Chrome on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+	// Chrome on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+	// Chrome on Linux
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+	// Firefox on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+	// Firefox on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 14.3; rv:123.0) Gecko/20100101 Firefox/123.0",
+	// Firefox on Linux
+	"Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+	// Safari on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.15",
+	// Edge on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0",
+}
+
+// UserAgentConfig configures the User-Agent rotation middleware.
+type UserAgentConfig struct {
+	// UserAgents is the pool of User-Agent strings to rotate through.
+	// If empty or nil, DefaultUserAgents is used.
+	UserAgents []string
+
+	// RotationMode controls how an agent is selected from the pool.
+	// Accepted values: RotationRoundRobin (default), RotationRandom, RotationPerDomain.
+	RotationMode string
+}
+
+// DefaultUserAgentConfig returns a UserAgentConfig with sensible defaults.
+func DefaultUserAgentConfig() UserAgentConfig {
+	return UserAgentConfig{
+		UserAgents:   DefaultUserAgents,
+		RotationMode: RotationRoundRobin,
+	}
+}
+
+// UserAgent is a middleware that sets the User-Agent request header by rotating
+// through a configurable pool of strings according to the selected rotation mode.
+type UserAgent struct {
+	cfg   UserAgentConfig
+	index atomic.Uint64 // Used by round-robin; incremented atomically.
+}
+
+// NewUserAgent creates a User-Agent rotation middleware.
+// If cfg.UserAgents is empty, DefaultUserAgents is used.
+// If cfg.RotationMode is unrecognised, RotationRoundRobin is used.
+func NewUserAgent(cfg UserAgentConfig) *UserAgent {
+	if len(cfg.UserAgents) == 0 {
+		cfg.UserAgents = DefaultUserAgents
+	}
+	switch cfg.RotationMode {
+	case RotationRoundRobin, RotationRandom, RotationPerDomain:
+		// valid
+	default:
+		cfg.RotationMode = RotationRoundRobin
+	}
+	return &UserAgent{cfg: cfg}
+}
+
+// ProcessRequest implements Middleware. It selects a User-Agent from the pool
+// according to the configured rotation mode, sets the "User-Agent" request header,
+// and forwards the request to the next handler.
+func (ua *UserAgent) ProcessRequest(ctx context.Context, req *Request, next NextFunc) (*Response, error) {
+	agent := ua.pick(req.URL)
+
+	if req.Headers == nil {
+		req.Headers = make(map[string]string)
+	}
+	req.Headers["User-Agent"] = agent
+
+	return next(ctx, req)
+}
+
+// pick selects a User-Agent string from the pool using the configured rotation mode.
+func (ua *UserAgent) pick(rawURL string) string {
+	pool := ua.cfg.UserAgents
+	n := uint64(len(pool))
+
+	switch ua.cfg.RotationMode {
+	case RotationRandom:
+		return pool[rand.Uint64N(n)] //nolint:gosec // non-cryptographic selection is intentional
+	case RotationPerDomain:
+		host := extractHost(rawURL)
+		if host == "" {
+			break
+		}
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(host))
+		return pool[h.Sum64()%n]
+	}
+
+	// Default: round-robin (also fallback for per-domain with unparseable URL).
+	idx := ua.index.Add(1) - 1
+	return pool[idx%n]
+}

--- a/pkg/middleware/useragent_test.go
+++ b/pkg/middleware/useragent_test.go
@@ -1,0 +1,249 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// nopHandler is a terminal handler that always returns 200.
+func nopHandler(_ context.Context, _ *Request) (*Response, error) {
+	return &Response{StatusCode: 200}, nil
+}
+
+func TestUserAgent_DefaultConfig(t *testing.T) {
+	cfg := DefaultUserAgentConfig()
+	if len(cfg.UserAgents) == 0 {
+		t.Error("DefaultUserAgentConfig: UserAgents must not be empty")
+	}
+	if cfg.RotationMode != RotationRoundRobin {
+		t.Errorf("DefaultUserAgentConfig: RotationMode = %q, want %q", cfg.RotationMode, RotationRoundRobin)
+	}
+}
+
+func TestUserAgent_EmptyPoolFallsBackToDefaults(t *testing.T) {
+	ua := NewUserAgent(UserAgentConfig{UserAgents: nil})
+	if len(ua.cfg.UserAgents) == 0 {
+		t.Error("NewUserAgent with nil pool: expected fallback to DefaultUserAgents")
+	}
+}
+
+func TestUserAgent_InvalidModeFallsBackToRoundRobin(t *testing.T) {
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   DefaultUserAgents,
+		RotationMode: "unknown-mode",
+	})
+	if ua.cfg.RotationMode != RotationRoundRobin {
+		t.Errorf("RotationMode = %q, want %q", ua.cfg.RotationMode, RotationRoundRobin)
+	}
+}
+
+func TestUserAgent_SetsHeader(t *testing.T) {
+	req := &Request{URL: "http://example.com"}
+	c := NewChain(nopHandler)
+	c.Use(NewUserAgent(DefaultUserAgentConfig()))
+
+	if _, err := c.Execute(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Headers["User-Agent"] == "" {
+		t.Error("User-Agent header must not be empty after middleware")
+	}
+}
+
+func TestUserAgent_InitialisesNilHeaderMap(t *testing.T) {
+	req := &Request{URL: "http://example.com", Headers: nil}
+	ua := NewUserAgent(DefaultUserAgentConfig())
+	if _, err := ua.ProcessRequest(context.Background(), req, nopHandler); err != nil {
+		t.Fatal(err)
+	}
+	if req.Headers == nil {
+		t.Error("Headers map must be initialised by middleware")
+	}
+	if req.Headers["User-Agent"] == "" {
+		t.Error("User-Agent header must be set")
+	}
+}
+
+func TestUserAgent_RoundRobin_Cycles(t *testing.T) {
+	pool := []string{"UA-A", "UA-B", "UA-C"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationRoundRobin,
+	})
+
+	req := func() *Request { return &Request{URL: "http://example.com"} }
+
+	for i := 0; i < len(pool)*3; i++ {
+		r := req()
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		want := pool[i%len(pool)]
+		if r.Headers["User-Agent"] != want {
+			t.Errorf("request %d: User-Agent = %q, want %q", i, r.Headers["User-Agent"], want)
+		}
+	}
+}
+
+func TestUserAgent_RoundRobin_SingleAgent(t *testing.T) {
+	pool := []string{"only-agent"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationRoundRobin,
+	})
+
+	for i := 0; i < 5; i++ {
+		r := &Request{URL: "http://example.com"}
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		if r.Headers["User-Agent"] != "only-agent" {
+			t.Errorf("User-Agent = %q, want %q", r.Headers["User-Agent"], "only-agent")
+		}
+	}
+}
+
+func TestUserAgent_RoundRobin_Concurrent(t *testing.T) {
+	pool := []string{"UA-A", "UA-B", "UA-C"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationRoundRobin,
+	})
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			r := &Request{URL: "http://example.com"}
+			if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			agent := r.Headers["User-Agent"]
+			valid := false
+			for _, p := range pool {
+				if agent == p {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				t.Errorf("User-Agent %q not in pool", agent)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestUserAgent_Random_PicksFromPool(t *testing.T) {
+	pool := []string{"UA-A", "UA-B", "UA-C"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationRandom,
+	})
+
+	for range 30 {
+		r := &Request{URL: "http://example.com"}
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		agent := r.Headers["User-Agent"]
+		found := false
+		for _, p := range pool {
+			if agent == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("random User-Agent %q is not in pool", agent)
+		}
+	}
+}
+
+func TestUserAgent_PerDomain_Stable(t *testing.T) {
+	pool := []string{"UA-A", "UA-B", "UA-C"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationPerDomain,
+	})
+
+	// Same domain must always produce the same agent.
+	r1 := &Request{URL: "http://example.com/page1"}
+	r2 := &Request{URL: "http://example.com/page2"}
+
+	if _, err := ua.ProcessRequest(context.Background(), r1, nopHandler); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ua.ProcessRequest(context.Background(), r2, nopHandler); err != nil {
+		t.Fatal(err)
+	}
+	if r1.Headers["User-Agent"] != r2.Headers["User-Agent"] {
+		t.Errorf("same domain: got %q and %q, want identical agents",
+			r1.Headers["User-Agent"], r2.Headers["User-Agent"])
+	}
+}
+
+func TestUserAgent_PerDomain_DifferentDomains(t *testing.T) {
+	// Use a large pool to reduce the probability of a collision.
+	pool := make([]string, 16)
+	for i := range pool {
+		pool[i] = fmt.Sprintf("UA-%d", i)
+	}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationPerDomain,
+	})
+
+	domains := []string{
+		"http://alpha.com",
+		"http://beta.com",
+		"http://gamma.com",
+	}
+
+	agents := make(map[string]string, len(domains))
+	for _, url := range domains {
+		r := &Request{URL: url}
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		agents[url] = r.Headers["User-Agent"]
+	}
+
+	// Verify each domain returns the same agent on repeated calls.
+	for _, url := range domains {
+		r := &Request{URL: url}
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		if r.Headers["User-Agent"] != agents[url] {
+			t.Errorf("domain %s: second call returned %q, want %q",
+				url, r.Headers["User-Agent"], agents[url])
+		}
+	}
+}
+
+func TestUserAgent_PerDomain_UnparsableURLFallsBackToRoundRobin(t *testing.T) {
+	pool := []string{"UA-A", "UA-B", "UA-C"}
+	ua := NewUserAgent(UserAgentConfig{
+		UserAgents:   pool,
+		RotationMode: RotationPerDomain,
+	})
+
+	// An unparseable or empty URL should fall through to round-robin.
+	for i := 0; i < len(pool); i++ {
+		r := &Request{URL: "://invalid-url"}
+		if _, err := ua.ProcessRequest(context.Background(), r, nopHandler); err != nil {
+			t.Fatal(err)
+		}
+		want := pool[i%len(pool)]
+		if r.Headers["User-Agent"] != want {
+			t.Errorf("request %d: User-Agent = %q, want %q", i, r.Headers["User-Agent"], want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `UserAgent` middleware to `pkg/middleware` that rotates through a configurable pool of User-Agent strings on each HTTP request.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `pkg/middleware/useragent.go` — new middleware
- `pkg/middleware/useragent_test.go` — 12 unit tests

## Why

### Related Issues
Closes #76
Part of #23 (Epic: Advanced middleware — Proxy Rotation, Auth, User-Agent, Cache)

### Motivation
FR-504 / SRS-MW-006 require User-Agent rotation so the crawler can blend in with normal browser traffic at high throughput, reducing the risk of being rate-limited or blocked based on a static UA string.

## How

### Implementation Details

Three rotation modes are supported:

| Mode | Behaviour |
|------|-----------|
| `round-robin` (default) | Atomic `uint64` increment; goroutine-safe without a mutex |
| `random` | `math/rand/v2.Uint64N` — non-cryptographic, intentional |
| `per-domain` | FNV-64a hash of the URL host → stable index per hostname |

`DefaultUserAgents` provides 8 realistic browser strings (Chrome/Firefox/Safari/Edge on Win/Mac/Linux).

`NewUserAgent` falls back to `DefaultUserAgents` on an empty pool and to `round-robin` on an unrecognised mode — no panics on bad config.

### Testing Done
- [x] 12 unit tests covering all three rotation modes, concurrency (50 goroutines), edge cases (empty pool, single-agent pool, unparseable URL, nil header map)
- [x] `go test ./pkg/middleware/...` — all pass
- [x] `go vet ./pkg/middleware/...` — clean

### Test Plan
```bash
go test ./pkg/middleware/... -v -run TestUserAgent
```

### Breaking Changes
None — new file only; no existing code modified.