### PR TITLE
feat(storage): migrate storage backends to plugin.StoragePlugin interface

### DIFF
--- a/pkg/plugin/builtin.go
+++ b/pkg/plugin/builtin.go
@@ -1,0 +1,23 @@
+package plugin
+
+import "github.com/kcenon/web_crawler/pkg/storage"
+
+// Compile-time interface verification: every built-in storage backend
+// must satisfy both the legacy storage.Plugin and the new plugin.StoragePlugin.
+var (
+	_ StoragePlugin = (*storage.FileStorage)(nil)
+	_ StoragePlugin = (*storage.CSVStorage)(nil)
+	_ StoragePlugin = (*storage.PostgresPlugin)(nil)
+)
+
+// RegisterBuiltinStorage registers the provided storage backends in the
+// registry under their Name(). It is a convenience for wiring up all
+// built-in storage implementations at application startup.
+func RegisterBuiltinStorage(r *Registry, plugins ...StoragePlugin) error {
+	for _, p := range plugins {
+		if err := r.RegisterStorage(p.Name(), p); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/plugin/builtin_test.go
+++ b/pkg/plugin/builtin_test.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/kcenon/web_crawler/pkg/storage"
+)
+
+func TestStorageBackends_ImplementStoragePlugin(t *testing.T) {
+	// Verify Name() returns expected identifiers.
+	tests := []struct {
+		name string
+		p    StoragePlugin
+		want string
+	}{
+		{"FileStorage", storage.NewFileStorage(storage.FileConfig{Path: "/dev/null"}), "file"},
+		{"CSVStorage", storage.NewCSVStorage(storage.CSVConfig{Path: "/dev/null"}), "csv"},
+		{"PostgresPlugin", storage.NewPostgresPlugin(storage.PostgresConfig{DSN: "postgres://localhost/test"}), "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.Name(); got != tt.want {
+				t.Errorf("Name() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisterBuiltinStorage(t *testing.T) {
+	r := NewRegistry()
+
+	file := storage.NewFileStorage(storage.FileConfig{Path: "/dev/null"})
+	csvs := storage.NewCSVStorage(storage.CSVConfig{Path: "/dev/null"})
+
+	if err := RegisterBuiltinStorage(r, file, csvs); err != nil {
+		t.Fatal(err)
+	}
+
+	names := r.ListStorage()
+	if len(names) != 2 {
+		t.Fatalf("registered %d plugins, want 2", len(names))
+	}
+
+	// Verify retrieval works.
+	got, err := r.GetStorage("file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name() != "file" {
+		t.Errorf("got Name() = %q, want %q", got.Name(), "file")
+	}
+}
+
+func TestRegisterBuiltinStorage_Duplicate(t *testing.T) {
+	r := NewRegistry()
+
+	file1 := storage.NewFileStorage(storage.FileConfig{Path: "/dev/null"})
+	file2 := storage.NewFileStorage(storage.FileConfig{Path: "/dev/null"})
+
+	if err := RegisterBuiltinStorage(r, file1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Registering a second plugin with the same Name should fail.
+	err := RegisterBuiltinStorage(r, file2)
+	if err == nil {
+		t.Error("expected duplicate registration error")
+	}
+}

--- a/pkg/storage/csv.go
+++ b/pkg/storage/csv.go
@@ -39,6 +39,9 @@ func NewCSVStorage(cfg CSVConfig) *CSVStorage {
 	return &CSVStorage{cfg: cfg}
 }
 
+// Name returns the plugin identifier for this storage backend.
+func (c *CSVStorage) Name() string { return "csv" }
+
 // Init opens the output file and prepares the CSV writer.
 func (c *CSVStorage) Init(config map[string]any) error {
 	if p, ok := config["path"].(string); ok && p != "" {

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -31,6 +31,9 @@ func NewFileStorage(cfg FileConfig) *FileStorage {
 	return &FileStorage{cfg: cfg}
 }
 
+// Name returns the plugin identifier for this storage backend.
+func (f *FileStorage) Name() string { return "file" }
+
 // Init opens the output file for append-mode writing.
 func (f *FileStorage) Init(config map[string]any) error {
 	if p, ok := config["path"].(string); ok && p != "" {

--- a/pkg/storage/postgres.go
+++ b/pkg/storage/postgres.go
@@ -41,6 +41,9 @@ func NewPostgresPlugin(cfg PostgresConfig) *PostgresPlugin {
 	return &PostgresPlugin{cfg: cfg}
 }
 
+// Name returns the plugin identifier for this storage backend.
+func (p *PostgresPlugin) Name() string { return "postgres" }
+
 // Init connects to PostgreSQL and runs pending migrations.
 func (p *PostgresPlugin) Init(config map[string]any) error {
 	if dsn, ok := config["dsn"].(string); ok && dsn != "" {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -463,3 +463,26 @@ func TestFlattenItem(t *testing.T) {
 		t.Errorf("expected data.nested.key='value', got %q", flat["data.nested.key"])
 	}
 }
+
+// --- Name() method tests ---
+
+func TestFileStorage_Name(t *testing.T) {
+	fs := NewFileStorage(FileConfig{Path: "/dev/null"})
+	if fs.Name() != "file" {
+		t.Errorf("Name() = %q, want %q", fs.Name(), "file")
+	}
+}
+
+func TestCSVStorage_Name(t *testing.T) {
+	cs := NewCSVStorage(CSVConfig{Path: "/dev/null"})
+	if cs.Name() != "csv" {
+		t.Errorf("Name() = %q, want %q", cs.Name(), "csv")
+	}
+}
+
+func TestPostgresPlugin_Name(t *testing.T) {
+	pg := NewPostgresPlugin(PostgresConfig{DSN: "postgres://localhost/test"})
+	if pg.Name() != "postgres" {
+		t.Errorf("Name() = %q, want %q", pg.Name(), "postgres")
+	}
+}


### PR DESCRIPTION
Closes #86

## What

### Summary
Migrates existing storage backends (FileStorage, CSVStorage, PostgresPlugin) to implement the new `plugin.StoragePlugin` interface by adding a `Name()` method to each. This enables all storage backends to be discovered, configured, and managed through the unified plugin registry.

### Change Type
- [x] Feature (new functionality)

## Why

### Problem Solved
Storage backends were isolated from the new plugin system (created in #85). This migration allows them to participate in the unified plugin lifecycle and registry.

### Related Issues
- Closes #86 (Migrate storage backends to plugin system)
- Part of #24 (Epic: Plugin system architecture and implementation)
- Depends on #85 (Plugin base interface and registry) - merged

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `pkg/storage/` | 3 | Added Name() method |
| `pkg/storage/` | 1 | Added Name() tests |
| `pkg/plugin/` | 2 | New builtin registration |

### API Changes
New methods on existing types (backward compatible):
- `FileStorage.Name() string` returns `"file"`
- `CSVStorage.Name() string` returns `"csv"`
- `PostgresPlugin.Name() string` returns `"postgres"`

New helper function:
- `plugin.RegisterBuiltinStorage(r *Registry, plugins ...StoragePlugin) error`

## How

### Implementation Details
1. Added `Name() string` to each storage backend - Go structural typing means they now satisfy both `storage.Plugin` and `plugin.StoragePlugin`
2. Compile-time interface checks in `pkg/plugin/builtin.go` ensure conformance
3. `RegisterBuiltinStorage` helper for convenient registry wiring at startup

### Testing Done
- [x] 17 storage tests pass (including 3 new Name() tests)
- [x] 36 plugin tests pass (including 3 new builtin tests)
- [x] gofmt clean

### Test Plan
1. `go test ./pkg/storage/` - All 17 tests pass
2. `go test ./pkg/plugin/` - All 36 tests pass
3. Verify existing code in `examples/storage/main.go` still compiles

### Breaking Changes
None - additive only