### PR TITLE
feat(plugin): add HTML parser plugin and content-type router

### DIFF
--- a/pkg/plugin/parser/html.go
+++ b/pkg/plugin/parser/html.go
@@ -1,0 +1,85 @@
+// Package parser provides built-in ParserPlugin implementations.
+package parser
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+	"github.com/kcenon/web_crawler/pkg/plugin"
+)
+
+// HTMLParser extracts structured data and links from HTML responses
+// using GoQuery CSS selectors.
+type HTMLParser struct {
+	// Rules maps field names to CSS selectors for data extraction.
+	// Each selector's text content is placed under the corresponding key
+	// in ParseResult.Data. If nil, only link extraction is performed.
+	Rules map[string]string
+}
+
+// NewHTMLParser creates an HTMLParser with the given extraction rules.
+// Pass nil for link-only extraction.
+func NewHTMLParser(rules map[string]string) *HTMLParser {
+	return &HTMLParser{Rules: rules}
+}
+
+// Name returns the plugin identifier.
+func (h *HTMLParser) Name() string { return "html" }
+
+// Init is a no-op; HTMLParser requires no initialisation.
+func (h *HTMLParser) Init(map[string]any) error { return nil }
+
+// Close is a no-op; HTMLParser holds no resources.
+func (h *HTMLParser) Close() error { return nil }
+
+// CanParse reports whether the content type is HTML.
+func (h *HTMLParser) CanParse(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	return strings.Contains(ct, "text/html") || strings.Contains(ct, "application/xhtml")
+}
+
+// Parse extracts data and links from the crawl response body.
+func (h *HTMLParser) Parse(_ context.Context, resp *crawler.CrawlResponse) (*plugin.ParseResult, error) {
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(resp.Body))
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]any)
+
+	// Apply extraction rules.
+	for name, sel := range h.Rules {
+		var values []string
+		doc.Find(sel).Each(func(_ int, s *goquery.Selection) {
+			values = append(values, strings.TrimSpace(s.Text()))
+		})
+		if len(values) == 1 {
+			data[name] = values[0]
+		} else if len(values) > 1 {
+			data[name] = values
+		}
+	}
+
+	// Extract links from <a href="..."> elements.
+	var links []string
+	doc.Find("a[href]").Each(func(_ int, s *goquery.Selection) {
+		if href, exists := s.Attr("href"); exists {
+			href = strings.TrimSpace(href)
+			if href != "" && href != "#" {
+				links = append(links, href)
+			}
+		}
+	})
+
+	return &plugin.ParseResult{
+		Data:  data,
+		Links: links,
+	}, nil
+}
+
+// Compile-time interface check.
+var _ plugin.ParserPlugin = (*HTMLParser)(nil)

--- a/pkg/plugin/parser/html_test.go
+++ b/pkg/plugin/parser/html_test.go
@@ -1,0 +1,141 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+)
+
+const testHTML = `<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+  <h1>Hello World</h1>
+  <p class="desc">A description</p>
+  <a href="https://example.com/page1">Link 1</a>
+  <a href="https://example.com/page2">Link 2</a>
+  <a href="#">Empty</a>
+  <a href="">Blank</a>
+</body>
+</html>`
+
+func resp(ct string, body string) *crawler.CrawlResponse {
+	return &crawler.CrawlResponse{
+		Request:     &crawler.CrawlRequest{URL: "https://example.com"},
+		StatusCode:  200,
+		Body:        []byte(body),
+		ContentType: ct,
+	}
+}
+
+func TestHTMLParser_Name(t *testing.T) {
+	p := NewHTMLParser(nil)
+	if p.Name() != "html" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "html")
+	}
+}
+
+func TestHTMLParser_CanParse(t *testing.T) {
+	p := NewHTMLParser(nil)
+
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"text/html", true},
+		{"text/html; charset=utf-8", true},
+		{"TEXT/HTML", true},
+		{"application/xhtml+xml", true},
+		{"application/json", false},
+		{"text/plain", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := p.CanParse(tt.ct); got != tt.want {
+			t.Errorf("CanParse(%q) = %v, want %v", tt.ct, got, tt.want)
+		}
+	}
+}
+
+func TestHTMLParser_Parse_LinksOnly(t *testing.T) {
+	p := NewHTMLParser(nil)
+	result, err := p.Parse(context.Background(), resp("text/html", testHTML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Links) != 2 {
+		t.Fatalf("got %d links, want 2", len(result.Links))
+	}
+	if result.Links[0] != "https://example.com/page1" {
+		t.Errorf("links[0] = %q", result.Links[0])
+	}
+	if result.Links[1] != "https://example.com/page2" {
+		t.Errorf("links[1] = %q", result.Links[1])
+	}
+}
+
+func TestHTMLParser_Parse_WithRules(t *testing.T) {
+	rules := map[string]string{
+		"title": "title",
+		"h1":    "h1",
+		"desc":  "p.desc",
+	}
+	p := NewHTMLParser(rules)
+	result, err := p.Parse(context.Background(), resp("text/html", testHTML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Data["title"] != "Test Page" {
+		t.Errorf("title = %v, want %q", result.Data["title"], "Test Page")
+	}
+	if result.Data["h1"] != "Hello World" {
+		t.Errorf("h1 = %v, want %q", result.Data["h1"], "Hello World")
+	}
+	if result.Data["desc"] != "A description" {
+		t.Errorf("desc = %v, want %q", result.Data["desc"], "A description")
+	}
+}
+
+func TestHTMLParser_Parse_MultipleMatches(t *testing.T) {
+	html := `<ul><li>A</li><li>B</li><li>C</li></ul>`
+	p := NewHTMLParser(map[string]string{"items": "li"})
+	result, err := p.Parse(context.Background(), resp("text/html", html))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, ok := result.Data["items"].([]string)
+	if !ok {
+		t.Fatalf("items is %T, want []string", result.Data["items"])
+	}
+	if len(items) != 3 {
+		t.Errorf("got %d items, want 3", len(items))
+	}
+}
+
+func TestHTMLParser_Parse_NoLinks(t *testing.T) {
+	html := `<p>No links here</p>`
+	p := NewHTMLParser(nil)
+	result, err := p.Parse(context.Background(), resp("text/html", html))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Links) != 0 {
+		t.Errorf("got %d links, want 0", len(result.Links))
+	}
+}
+
+func TestHTMLParser_InitAndClose(t *testing.T) {
+	p := NewHTMLParser(nil)
+	if err := p.Init(nil); err != nil {
+		t.Errorf("Init() error = %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}

--- a/pkg/plugin/router.go
+++ b/pkg/plugin/router.go
@@ -1,0 +1,37 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+)
+
+// ParserRouter selects and invokes the appropriate ParserPlugin based
+// on the content type of a crawl response. It iterates over registered
+// parsers and uses the first one whose CanParse returns true.
+type ParserRouter struct {
+	registry *Registry
+}
+
+// NewParserRouter creates a router backed by the given registry.
+func NewParserRouter(r *Registry) *ParserRouter {
+	return &ParserRouter{registry: r}
+}
+
+// Parse finds a suitable parser for the response's content type and
+// delegates to it. Returns ErrNoParser if no registered parser can
+// handle the content type.
+func (pr *ParserRouter) Parse(ctx context.Context, resp *crawler.CrawlResponse) (*ParseResult, error) {
+	names := pr.registry.ListParsers()
+	for _, name := range names {
+		p, err := pr.registry.GetParser(name)
+		if err != nil {
+			continue
+		}
+		if p.CanParse(resp.ContentType) {
+			return p.Parse(ctx, resp)
+		}
+	}
+	return nil, fmt.Errorf("plugin: no parser registered for content type %q", resp.ContentType)
+}

--- a/pkg/plugin/router_test.go
+++ b/pkg/plugin/router_test.go
@@ -1,0 +1,106 @@
+package plugin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/web_crawler/pkg/crawler"
+)
+
+// testParser is a minimal ParserPlugin for router testing.
+type testParser struct {
+	name string
+	ct   string // content type prefix to match
+}
+
+func (p *testParser) Name() string              { return p.name }
+func (p *testParser) Init(map[string]any) error { return nil }
+func (p *testParser) Close() error              { return nil }
+func (p *testParser) CanParse(ct string) bool   { return strings.Contains(ct, p.ct) }
+func (p *testParser) Parse(_ context.Context, resp *crawler.CrawlResponse) (*ParseResult, error) {
+	return &ParseResult{
+		Data: map[string]any{"parser": p.name, "url": resp.Request.URL},
+	}, nil
+}
+
+func TestParserRouter_MatchesCorrectParser(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterParser("html", &testParser{name: "html", ct: "text/html"})
+	_ = r.RegisterParser("json", &testParser{name: "json", ct: "application/json"})
+
+	router := NewParserRouter(r)
+
+	resp := &crawler.CrawlResponse{
+		Request:     &crawler.CrawlRequest{URL: "https://example.com"},
+		ContentType: "text/html; charset=utf-8",
+		Body:        []byte("<html></html>"),
+	}
+
+	result, err := router.Parse(context.Background(), resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Data["parser"] != "html" {
+		t.Errorf("expected html parser, got %v", result.Data["parser"])
+	}
+}
+
+func TestParserRouter_JSONContentType(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterParser("html", &testParser{name: "html", ct: "text/html"})
+	_ = r.RegisterParser("json", &testParser{name: "json", ct: "application/json"})
+
+	router := NewParserRouter(r)
+
+	resp := &crawler.CrawlResponse{
+		Request:     &crawler.CrawlRequest{URL: "https://api.example.com"},
+		ContentType: "application/json",
+		Body:        []byte(`{"key": "value"}`),
+	}
+
+	result, err := router.Parse(context.Background(), resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Data["parser"] != "json" {
+		t.Errorf("expected json parser, got %v", result.Data["parser"])
+	}
+}
+
+func TestParserRouter_NoMatchingParser(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterParser("html", &testParser{name: "html", ct: "text/html"})
+
+	router := NewParserRouter(r)
+
+	resp := &crawler.CrawlResponse{
+		Request:     &crawler.CrawlRequest{URL: "https://example.com"},
+		ContentType: "application/pdf",
+		Body:        []byte{},
+	}
+
+	_, err := router.Parse(context.Background(), resp)
+	if err == nil {
+		t.Error("expected error for unhandled content type")
+	}
+	if !strings.Contains(err.Error(), "application/pdf") {
+		t.Errorf("error should mention content type, got: %v", err)
+	}
+}
+
+func TestParserRouter_EmptyRegistry(t *testing.T) {
+	r := NewRegistry()
+	router := NewParserRouter(r)
+
+	resp := &crawler.CrawlResponse{
+		Request:     &crawler.CrawlRequest{URL: "https://example.com"},
+		ContentType: "text/html",
+		Body:        []byte("<html></html>"),
+	}
+
+	_, err := router.Parse(context.Background(), resp)
+	if err == nil {
+		t.Error("expected error for empty registry")
+	}
+}


### PR DESCRIPTION
Closes #87

## What

### Summary
Implements the `ParserPlugin` interface with a concrete HTML parser using GoQuery and a content-type based `ParserRouter` for automatic parser selection.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `pkg/plugin/parser/html.go` - HTML parser plugin with CSS selector extraction and link discovery
- `pkg/plugin/router.go` - Content-type router that delegates to registered parsers

## Why

### Related Issues
- Closes #87 (Parser plugin interface and content-type routing)
- Part of #24 (Epic: Plugin system architecture and implementation)
- Depends on #85 (Plugin base interface) - merged

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `pkg/plugin/parser/` | 2 | New package |
| `pkg/plugin/` | 2 | New router |

### API Changes
- `parser.HTMLParser` - ParserPlugin for HTML content
- `parser.NewHTMLParser(rules map[string]string)` - Constructor
- `plugin.ParserRouter` - Content-type based parser routing
- `plugin.NewParserRouter(r *Registry)` - Constructor

## How

### Implementation Details
1. `HTMLParser` wraps GoQuery for CSS-based extraction
2. Configurable rules: `map[string]string` maps field names to CSS selectors
3. Link extraction from `<a href>` elements (filters empty/anchor-only)
4. `ParserRouter` iterates registered parsers, uses first matching `CanParse`

### Testing Done
- [x] 7 HTML parser tests (name, canparse, links, rules, multi-match)
- [x] 4 router tests (match, JSON routing, no match, empty registry)
- [x] gofmt clean

### Breaking Changes
None - new code only