### PR TITLE
feat(plugin): add webhook notifier plugin for crawl events

### DIFF
--- a/pkg/plugin/notifier/webhook.go
+++ b/pkg/plugin/notifier/webhook.go
@@ -1,0 +1,108 @@
+// Package notifier provides built-in NotifierPlugin implementations.
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/plugin"
+)
+
+// WebhookConfig configures the webhook notifier.
+type WebhookConfig struct {
+	// URL is the endpoint to POST event payloads to. Required.
+	URL string
+
+	// Timeout is the HTTP request timeout. Defaults to 10 seconds.
+	Timeout time.Duration
+
+	// Headers are extra HTTP headers sent with each request.
+	Headers map[string]string
+}
+
+// Webhook sends crawl events as JSON POST requests to a configured URL.
+type Webhook struct {
+	cfg    WebhookConfig
+	client *http.Client
+}
+
+// NewWebhook creates a webhook notifier with the given configuration.
+func NewWebhook(cfg WebhookConfig) *Webhook {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	return &Webhook{
+		cfg:    cfg,
+		client: &http.Client{Timeout: cfg.Timeout},
+	}
+}
+
+// Name returns the plugin identifier.
+func (w *Webhook) Name() string { return "webhook" }
+
+// Init validates the configuration. The URL can be overridden via the
+// config map key "url".
+func (w *Webhook) Init(config map[string]any) error {
+	if u, ok := config["url"].(string); ok && u != "" {
+		w.cfg.URL = u
+	}
+	if w.cfg.URL == "" {
+		return fmt.Errorf("webhook notifier: url is required")
+	}
+	return nil
+}
+
+// Close is a no-op; Webhook holds no persistent resources.
+func (w *Webhook) Close() error { return nil }
+
+// webhookPayload is the JSON body sent to the webhook endpoint.
+type webhookPayload struct {
+	Type    string         `json:"type"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data,omitempty"`
+	SentAt  time.Time      `json:"sent_at"`
+}
+
+// Notify posts the crawl event as JSON to the configured webhook URL.
+func (w *Webhook) Notify(ctx context.Context, event *plugin.CrawlEvent) error {
+	payload := webhookPayload{
+		Type:    string(event.Type),
+		Message: event.Message,
+		Data:    event.Data,
+		SentAt:  time.Now(),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("webhook notifier: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook notifier: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range w.cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook notifier: send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("webhook notifier: server returned %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Compile-time interface check.
+var _ plugin.NotifierPlugin = (*Webhook)(nil)

--- a/pkg/plugin/notifier/webhook_test.go
+++ b/pkg/plugin/notifier/webhook_test.go
@@ -1,0 +1,157 @@
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kcenon/web_crawler/pkg/plugin"
+)
+
+func TestWebhook_Name(t *testing.T) {
+	w := NewWebhook(WebhookConfig{URL: "http://example.com"})
+	if w.Name() != "webhook" {
+		t.Errorf("Name() = %q, want %q", w.Name(), "webhook")
+	}
+}
+
+func TestWebhook_Init_RequiresURL(t *testing.T) {
+	w := NewWebhook(WebhookConfig{})
+	if err := w.Init(nil); err == nil {
+		t.Error("expected error for missing URL")
+	}
+}
+
+func TestWebhook_Init_URLFromConfig(t *testing.T) {
+	w := NewWebhook(WebhookConfig{})
+	if err := w.Init(map[string]any{"url": "http://example.com/hook"}); err != nil {
+		t.Fatal(err)
+	}
+	if w.cfg.URL != "http://example.com/hook" {
+		t.Errorf("URL = %q, want %q", w.cfg.URL, "http://example.com/hook")
+	}
+}
+
+func TestWebhook_Notify_SendsJSON(t *testing.T) {
+	var received webhookPayload
+	var receivedHeaders http.Header
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w := NewWebhook(WebhookConfig{
+		URL:     srv.URL,
+		Headers: map[string]string{"X-Custom": "test-value"},
+	})
+	_ = w.Init(nil)
+
+	event := &plugin.CrawlEvent{
+		Type:    plugin.EventCompleted,
+		Message: "crawl finished",
+		Data:    map[string]any{"pages": 42},
+	}
+
+	if err := w.Notify(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+
+	if received.Type != "completed" {
+		t.Errorf("type = %q, want %q", received.Type, "completed")
+	}
+	if received.Message != "crawl finished" {
+		t.Errorf("message = %q, want %q", received.Message, "crawl finished")
+	}
+	if received.SentAt.IsZero() {
+		t.Error("expected non-zero sent_at")
+	}
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q", receivedHeaders.Get("Content-Type"))
+	}
+	if receivedHeaders.Get("X-Custom") != "test-value" {
+		t.Errorf("X-Custom = %q", receivedHeaders.Get("X-Custom"))
+	}
+}
+
+func TestWebhook_Notify_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	w := NewWebhook(WebhookConfig{URL: srv.URL})
+	_ = w.Init(nil)
+
+	event := &plugin.CrawlEvent{Type: plugin.EventError, Message: "test"}
+
+	err := w.Notify(context.Background(), event)
+	if err == nil {
+		t.Error("expected error for 500 response")
+	}
+}
+
+func TestWebhook_Notify_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w := NewWebhook(WebhookConfig{URL: srv.URL, Timeout: 100 * time.Millisecond})
+	_ = w.Init(nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	event := &plugin.CrawlEvent{Type: plugin.EventStarted, Message: "start"}
+	err := w.Notify(ctx, event)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+func TestWebhook_Notify_AllEventTypes(t *testing.T) {
+	types := []plugin.EventType{
+		plugin.EventStarted,
+		plugin.EventCompleted,
+		plugin.EventError,
+		plugin.EventThreshold,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w := NewWebhook(WebhookConfig{URL: srv.URL})
+	_ = w.Init(nil)
+
+	for _, et := range types {
+		event := &plugin.CrawlEvent{Type: et, Message: string(et)}
+		if err := w.Notify(context.Background(), event); err != nil {
+			t.Errorf("Notify(%s) error: %v", et, err)
+		}
+	}
+}
+
+func TestWebhook_Close(t *testing.T) {
+	w := NewWebhook(WebhookConfig{URL: "http://example.com"})
+	if err := w.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}
+
+func TestWebhook_DefaultTimeout(t *testing.T) {
+	w := NewWebhook(WebhookConfig{URL: "http://example.com"})
+	if w.cfg.Timeout != 10*time.Second {
+		t.Errorf("default timeout = %v, want 10s", w.cfg.Timeout)
+	}
+}


### PR DESCRIPTION
Closes #88

## What

### Summary
Implements a webhook-based `NotifierPlugin` that sends crawl events as JSON POST requests to a configured endpoint. This serves as the reference implementation for the notifier plugin category.

### Change Type
- [x] Feature (new functionality)

## Why

### Related Issues
- Closes #88 (Notifier plugin interface for crawl events)
- Part of #24 (Epic: Plugin system architecture and implementation)

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `pkg/plugin/notifier/` | 2 | New package |

### API Changes
- `notifier.Webhook` - NotifierPlugin for webhook delivery
- `notifier.NewWebhook(cfg WebhookConfig)` - Constructor
- `notifier.WebhookConfig` - URL, Timeout, Headers configuration

## How

### Implementation Details
1. JSON payload with type, message, data, and sent_at fields
2. Context-aware HTTP client with configurable timeout (default 10s)
3. Custom headers support for authentication tokens
4. Server error detection (4xx/5xx status codes)

### Testing Done
- [x] 9 tests using httptest.NewServer for real HTTP round-trips
- [x] Tests cover: name, init validation, JSON delivery, server errors, context cancellation, all event types
- [x] gofmt clean

### Breaking Changes
None - new package only