### PR TITLE
chore(security): add Dependabot configuration for dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "component:infra"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "component:infra"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "component:infra"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

### Summary
Add GitHub Dependabot configuration for automated dependency vulnerability scanning and updates across Go modules, GitHub Actions, and Python pip ecosystems.

### Change Type
- [x] Chore

## Why

### Related Issues
- Closes #98
- Part of #27 (Security audit and compliance hardening)

### Motivation
No automated dependency vulnerability scanning existed. Known CVEs in transitive dependencies could go undetected.

## Where

| File | Type of Change |
|------|----------------|
| `.github/dependabot.yml` | New configuration |

## How

### Configuration
- **Go modules**: Weekly scan on Monday, `chore(deps)` prefix
- **GitHub Actions**: Weekly scan on Monday, `chore(ci)` prefix
- **Python pip**: Weekly scan on Monday, `chore(deps)` prefix
- All PRs labeled with `dependencies` and `component:infra`

### Breaking Changes
None — additive configuration only.