### PR TITLE
feat(security): add credential type with safe printing and env var loading

### DIFF
--- a/pkg/security/credential.go
+++ b/pkg/security/credential.go
@@ -1,0 +1,63 @@
+// Package security provides credential management utilities for safe handling
+// of sensitive values such as passwords, tokens, and API keys.
+package security
+
+import (
+	"fmt"
+	"os"
+)
+
+// Credential holds a sensitive string value with safe printing behavior.
+// Its String and GoString methods always return a redacted placeholder,
+// preventing accidental credential leakage through fmt, logging, or
+// debug output.
+//
+// Use [NewCredential] to create a credential from a literal value, or
+// [CredentialFromEnv] to load one from an environment variable.
+type Credential struct {
+	value string
+}
+
+// NewCredential creates a Credential from a plaintext value.
+func NewCredential(value string) Credential {
+	return Credential{value: value}
+}
+
+// CredentialFromEnv loads a credential from the named environment variable.
+// Returns an error if the variable is unset or empty.
+func CredentialFromEnv(envVar string) (Credential, error) {
+	v := os.Getenv(envVar)
+	if v == "" {
+		return Credential{}, fmt.Errorf("security: environment variable %s is not set or empty", envVar)
+	}
+	return Credential{value: v}, nil
+}
+
+// Value returns the plaintext credential. Use sparingly and only when the
+// actual value is needed (e.g., constructing an HTTP header).
+func (c Credential) Value() string {
+	return c.value
+}
+
+// IsEmpty reports whether the credential holds an empty value.
+func (c Credential) IsEmpty() bool {
+	return c.value == ""
+}
+
+// String always returns "[REDACTED]" to prevent accidental logging.
+// This implements fmt.Stringer.
+func (c Credential) String() string {
+	return "[REDACTED]"
+}
+
+// GoString always returns "[REDACTED]" to prevent exposure via %#v.
+// This implements fmt.GoStringer.
+func (c Credential) GoString() string {
+	return "[REDACTED]"
+}
+
+// MarshalText returns "[REDACTED]" when the credential is serialized as text
+// (e.g., JSON, YAML). This prevents accidental serialization of secrets.
+func (c Credential) MarshalText() ([]byte, error) {
+	return []byte("[REDACTED]"), nil
+}

--- a/pkg/security/credential_test.go
+++ b/pkg/security/credential_test.go
@@ -1,0 +1,103 @@
+package security
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestNewCredential(t *testing.T) {
+	c := NewCredential("my-secret")
+	if c.Value() != "my-secret" {
+		t.Errorf("expected Value()=%q, got %q", "my-secret", c.Value())
+	}
+}
+
+func TestCredential_IsEmpty(t *testing.T) {
+	empty := NewCredential("")
+	if !empty.IsEmpty() {
+		t.Error("expected empty credential to report IsEmpty=true")
+	}
+
+	full := NewCredential("value")
+	if full.IsEmpty() {
+		t.Error("expected non-empty credential to report IsEmpty=false")
+	}
+}
+
+func TestCredential_StringRedacted(t *testing.T) {
+	c := NewCredential("super-secret-token")
+
+	if c.String() != "[REDACTED]" {
+		t.Errorf("String() should return [REDACTED], got %q", c.String())
+	}
+
+	if c.GoString() != "[REDACTED]" {
+		t.Errorf("GoString() should return [REDACTED], got %q", c.GoString())
+	}
+}
+
+func TestCredential_FmtRedacted(t *testing.T) {
+	c := NewCredential("super-secret-token")
+
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"%s", "[REDACTED]"},
+		{"%v", "[REDACTED]"},
+		{"%#v", "[REDACTED]"},
+	}
+
+	for _, tt := range tests {
+		got := fmt.Sprintf(tt.format, c)
+		if got != tt.want {
+			t.Errorf("fmt.Sprintf(%q, cred) = %q, want %q", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestCredential_JSONRedacted(t *testing.T) {
+	type config struct {
+		APIKey Credential `json:"api_key"`
+	}
+
+	cfg := config{APIKey: NewCredential("sk-secret-123")}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	expected := `{"api_key":"[REDACTED]"}`
+	if string(data) != expected {
+		t.Errorf("JSON marshal should redact credential:\n got: %s\nwant: %s", data, expected)
+	}
+}
+
+func TestCredentialFromEnv(t *testing.T) {
+	t.Setenv("TEST_CRED_VAR", "env-secret")
+
+	c, err := CredentialFromEnv("TEST_CRED_VAR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Value() != "env-secret" {
+		t.Errorf("expected Value()=%q, got %q", "env-secret", c.Value())
+	}
+}
+
+func TestCredentialFromEnv_Unset(t *testing.T) {
+	_, err := CredentialFromEnv("NONEXISTENT_VAR_12345")
+	if err == nil {
+		t.Fatal("expected error for unset env var")
+	}
+}
+
+func TestCredentialFromEnv_Empty(t *testing.T) {
+	t.Setenv("TEST_EMPTY_CRED", "")
+
+	_, err := CredentialFromEnv("TEST_EMPTY_CRED")
+	if err == nil {
+		t.Fatal("expected error for empty env var")
+	}
+}


### PR DESCRIPTION
## What

### Summary
Add a `Credential` type in `pkg/security` that prevents accidental exposure of sensitive values through logging, fmt formatting, and JSON serialization.

### Change Type
- [x] Feature

## Why

### Related Issues
- Closes #100
- Part of #27 (Security audit and compliance hardening)

### Motivation
Credentials stored as plain strings risk accidental logging or serialization. The `Credential` type makes safe handling the default behavior.

## Where

| File | Type of Change |
|------|----------------|
| `pkg/security/credential.go` | New package |
| `pkg/security/credential_test.go` | Tests |

## How

### Implementation Details
- `String()` / `GoString()` → always `[REDACTED]` (prevents `%s`, `%v`, `%#v` leaks)
- `MarshalText()` → `[REDACTED]` (prevents JSON/YAML serialization)
- `CredentialFromEnv()` → loads from environment variable with validation
- `Value()` → explicit plaintext access for constructing headers/requests

### Testing Done
- [x] 8 test cases covering all redaction paths
- [x] fmt.Sprintf with %s, %v, %#v formats
- [x] JSON marshaling
- [x] Env var loading (set, unset, empty)

### Breaking Changes
None — new package, no existing code modified.